### PR TITLE
Handle multiselect

### DIFF
--- a/packages/protvista-zoomable/src/protvista-zoomable.js
+++ b/packages/protvista-zoomable/src/protvista-zoomable.js
@@ -341,6 +341,9 @@ class ProtvistaZoomable extends HTMLElement {
         detail.highlight = feature.fragments
           .map(fr => `${fr.start}:${fr.end}`)
           .join(",");
+      } else if (d3Event && d3Event.shiftKey && this._highlight) {
+        // If holding shift, add to the highlights
+        detail.highlight = `${this._highlight},${start}:${end}`;
       } else {
         detail.highlight = start && end ? `${start}:${end}` : null;
       }


### PR DESCRIPTION
### Reference to issue
Some users have requested to be able to select multiple features. This is especially useful when looking at variants and the 3D structure together.

### Description of changes
When Shift is pressed, if another feature/variant is clicked, its coordinates will be added to the list of coordinates for highlight. Clicking away or on another feature (with shift released) will reset that selection.

### Tests / Styleguide
 - [x] Tests pass
 - [x] Styleguide
