### PR TITLE
Unsafe svg

### DIFF
--- a/packages/protvista-datatable/package.json
+++ b/packages/protvista-datatable/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://ebi-webcomponents.github.io/nightingale/",
   "dependencies": {
-    "lit-element": "^2.1.0",
+    "lit-element": "^2.2.0",
     "uuid": "^3.3.3"
   },
   "gitHead": "5c6758c2c1ae3a9f0e664eef2293677b2a15e729"

--- a/packages/protvista-datatable/src/protvista-datatable.js
+++ b/packages/protvista-datatable/src/protvista-datatable.js
@@ -1,7 +1,7 @@
 import { LitElement, html } from "lit-element";
 import { v1 } from "uuid";
 /* eslint-disable import/extensions, import/no-extraneous-dependencies */
-import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
+import { unsafeSVG } from "lit-html/directives/unsafe-svg.js";
 import styles from "./styles";
 import PlusSVG from "../resources/plus.svg";
 import MinusSVG from "../resources/minus.svg";
@@ -269,8 +269,8 @@ class ProtvistaDatatable extends LitElement {
                           ${this.visibleChildren.includes(
                             row.protvistaFeatureId
                           )
-                            ? unsafeHTML(MinusSVG)
-                            : unsafeHTML(PlusSVG)}
+                            ? unsafeSVG(MinusSVG)
+                            : unsafeSVG(PlusSVG)}
                         </td>
                       `
                     : html`

--- a/packages/protvista-filter/package.json
+++ b/packages/protvista-filter/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "lit-element": "^2.2.0",
-    "lit-html": "^1.1.1",
     "lodash-es": "^4.17.11"
   },
   "keywords": [

--- a/packages/protvista-saver/package.json
+++ b/packages/protvista-saver/package.json
@@ -29,7 +29,7 @@
   "author": "Swaathi Kandasaamy",
   "license": "MIT",
   "dependencies": {
-    "lit-html": "^0.14.0",
+    "lit-html": "^1.2.0",
     "rasterizehtml": "^1.3.0"
   }
 }

--- a/packages/protvista-zoom-tool/package.json
+++ b/packages/protvista-zoom-tool/package.json
@@ -27,6 +27,6 @@
   "homepage": "https://ebi-webcomponents.github.io/nightingale/",
   "license": "MIT",
   "dependencies": {
-    "lit-html": "^0.14.0"
+    "lit-html": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7561,22 +7561,17 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lit-element@2.2.0, lit-element@^2.1.0, lit-element@^2.2.0:
+lit-element@2.2.0, lit-element@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.2.0.tgz#e853be38021f0c7743a10180affdf84b8a02400c"
   integrity sha512-Mzs3H7IO4wAnpzqreHw6dQqp9IG+h/oN8X9pgNbMZbE7x6B0aNOwP5Nveox/5HE+65ZfW2PeULEjoHkrwpTnuQ==
   dependencies:
     lit-html "^1.0.0"
 
-lit-html@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-0.14.0.tgz#d6830e8f55fb923b0f5824decf7da082a1d22997"
-  integrity sha512-+xqUPzzJGEDqb0F5DOnMXvL0jxpkKebAMlXycKZxFtzlmD+qePEmYrEUPF9XVXcc5eYBzYXTCOUcjSCod4YvgQ==
-
-lit-html@^1.0.0, lit-html@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.1.1.tgz#186ed6abcc70c0d24e1132b37411c3b2645ed1aa"
-  integrity sha512-1WqhkPpj+CKwLRXCCbyRGnWkcFKE4ft2+j8C2zaXwFUK9I2vYDzTuDGPh0H9hZcDBEwoe6YpPC8AO5734EPORQ==
+lit-html@^1.0.0, lit-html@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.2.1.tgz#1fb933dc1e2ddc095f60b8086277d4fcd9d62cc8"
+  integrity sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ==
 
 litemol@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
### Reference to issue
`unsafeHTML` warning in `protvista-datatable` row when `child` attribute is present as SVGs were being used inside the html template strings. `lit-html 1.2.0` provides `unsafeSVG` so upgraded packages to provide this.

### Description of changes
* Upgrade all lit-element to ^2.2.0
* Upgrade all lit-html to ^1.2.0.
* Remove lit-html dep from protvista-filter as lit-element already a dep.
* `protvista-datatable`: `unsafeHTML` --> `unsafeSVG`.

### Tests / Styleguide
 - [x] Tests pass
 - [x] Styleguide
