### PR TITLE
removing attributes instead of "null"

### DIFF
--- a/packages/protvista-manager/src/protvista-manager.js
+++ b/packages/protvista-manager/src/protvista-manager.js
@@ -109,7 +109,7 @@ class ProtVistaManager extends HTMLElement {
   applyAttributes() {
     this.protvistaElements.forEach((element) => {
       this.attributeValues.forEach((value, type) => {
-        if (value === false) {
+        if (value === false || value === null || value === undefined) {
           element.removeAttribute(type);
         } else {
           element.setAttribute(type, typeof value === "boolean" ? "" : value);


### PR DESCRIPTION
### Reference to issue
Some attributes were set to `"null"`. 

The most common example is the highlight in https://ebi-webcomponents.github.io/nightingale/#/manager if you mouse over any feature and then mouse out, you will see that all the tracks will have the attribute `highlight="null"`.
This is causing some issues in the InterPro website

### Description of changes
Just a one-liner to `removeAttribute` in case is null

### Tests / Styleguide
 - [X] Tests pass
 - [X] Styleguide
