### PR TITLE
Protvista track feature improvement

### DIFF
--- a/packages/protvista-track/src/protvista-track.js
+++ b/packages/protvista-track/src/protvista-track.js
@@ -207,6 +207,39 @@ class ProtvistaTrack extends ProtvistaZoomable {
         return feature.opacity ? feature.opacity : 0.9;
       })
       .call(this.bindEvents, this);
+
+    this.rectangles = this.locations
+        .selectAll("g.fragment-group")
+        .data((d) =>
+            d.fragments.map((loc) =>
+                Object.assign({}, loc, {
+                  feature: d.feature,
+                })
+            )
+        )
+        .enter()
+        .filter((f) => this._getShape(f) === 'helix')
+        .append("path")
+        .attr("class", 'outer-rectangle')
+        .attr("d", (f) =>
+            this._featureShape.getFeatureShape(
+                this.getSingleBaseWidth(),
+                this._layoutObj.getFeatureHeight(f),
+                f.end ? f.end - f.start + 1 : 1
+            )
+        )
+
+        .attr(
+            "transform",
+            (f) =>
+                `translate(${this.getXFromSeqPosition(
+                    f.start
+                )},${this._layoutObj.getFeatureYPos(f.feature)})`
+        )
+        .attr("fill", "transparent")
+        .attr("stroke", "transparent")
+        .style("fill-opacity", 0)
+        .call(this.bindEvents, this);
   }
 
   _applyFilters() {
@@ -263,6 +296,45 @@ class ProtvistaTrack extends ProtvistaZoomable {
               f.start
             )},${this._layoutObj.getFeatureYPos(f.feature)})`
         );
+
+      this.rectangles = this.seq_g.selectAll("path.outer-rectangle").data(
+          this._data.reduce(
+              (acc, f) =>
+                  acc.concat(
+                      f.locations.reduce(
+                          (acc2, e) =>
+                              acc2.concat(
+                                  e.fragments.map((loc) =>
+                                      Object.assign({}, loc, {
+                                        feature: f,
+                                      })
+                                  )
+                              ),
+                          []
+                      )
+                  ),
+              []
+          )
+      );
+
+      this.rectangles
+          .filter((f) => this._getShape(f) === 'helix')
+          .attr("d", (f) =>
+              this._featureShape.getFeatureShape(
+                  this.getSingleBaseWidth(),
+                  this._layoutObj.getFeatureHeight(f),
+                  f.end ? f.end - f.start + 1 : 1
+              )
+          )
+          .attr(
+              "transform",
+              (f) =>
+                  `translate(${this.getXFromSeqPosition(
+                      f.start
+                  )},${this._layoutObj.getFeatureYPos(f.feature)})`
+          )
+      ;
+
       this._updateHighlight();
     }
   }


### PR DESCRIPTION
### Reference to issue
The event is triggered on hovering over the feature shape. In cases like helix, or other shapes different than rectangle, it causes the event to trigger every time the mouse pointer moves between the path resulting in flickering like in https://github.com/ProteinsWebTeam/interpro7-client/issues/242

### Description of changes
An extra group is added `<g class="fragment-group"><path /><rect /></g>` in place of just the `<path>` and the rectangle is  responsible for event handling.

Could you please let us know if the above change is okay and goes well at your end?

