### PR TITLE
adding a higher order component withMargin

### DIFF
--- a/packages/protvista-navigation/package.json
+++ b/packages/protvista-navigation/package.json
@@ -25,7 +25,8 @@
   "license": "ISC",
   "gitHead": "3768065ef5b1f65e31acbf52e86cac3d98e347fb",
   "dependencies": {
-    "lodash-es": "^4.17.11"
+    "lodash-es": "^4.17.11",
+    "protvista-utils": "^2.18.0"
   },
   "devDependencies": {
     "d3": "^5.7.0"

--- a/packages/protvista-navigation/src/protvista-navigation.js
+++ b/packages/protvista-navigation/src/protvista-navigation.js
@@ -7,20 +7,21 @@ import {
   event as d3Event,
 } from "d3";
 
-const height = 40;
+import { withMargin } from "protvista-utils";
 
 class ProtVistaNavigation extends HTMLElement {
   constructor() {
     super();
     this._x = null;
     this._padding = 0;
+    this.height = 40;
     this.dontDispatch = false;
   }
 
   _refreshWidth() {
     this.style.display = "block";
     this.style.width = "100%";
-    this.width = this.offsetWidth;
+    this.width = this.offsetWidth - this.margin.left - this.margin.right;
     if (this.width > 0) {
       this._padding = 10;
     }
@@ -86,13 +87,13 @@ class ProtVistaNavigation extends HTMLElement {
     this._x = scaleLinear().range([this._padding, this.width - this._padding]);
     this._x.domain([this._rulerstart, this._rulerstart + this._length]);
 
-    this._svg = select(this)
-      .append("div")
-      .attr("class", "")
+    this._container = select(this).append("div").attr("class", "container");
+
+    this._svg = this._container
       .append("svg")
       .attr("id", "")
       .attr("width", this.width)
-      .attr("height", height);
+      .attr("height", this.height);
 
     this._xAxis = axisBottom(this._x);
 
@@ -100,13 +101,13 @@ class ProtVistaNavigation extends HTMLElement {
       .append("text")
       .attr("class", "start-label")
       .attr("x", 0)
-      .attr("y", height - this._padding);
+      .attr("y", this.height - this._padding);
 
     this._displayendLabel = this._svg
       .append("text")
       .attr("class", "end-label")
       .attr("x", this.width)
-      .attr("y", height - this._padding)
+      .attr("y", this.height - this._padding)
       .attr("text-anchor", "end");
     this._axis = this._svg
       .append("g")
@@ -116,7 +117,7 @@ class ProtVistaNavigation extends HTMLElement {
     this._viewport = brushX()
       .extent([
         [this._padding, 0],
-        [this.width - this._padding, height * 0.51],
+        [this.width - this._padding, this.height * 0.51],
       ])
       .on("brush", () => {
         if (d3Event.selection) {
@@ -171,7 +172,7 @@ class ProtVistaNavigation extends HTMLElement {
     this._svg.attr("width", this.width);
     this._viewport.extent([
       [this._padding, 0],
-      [this.width - this._padding, height * 0.51],
+      [this.width - this._padding, this.height * 0.51],
     ]);
     this._brushG.call(this._viewport);
     this._updateNavRuler();
@@ -179,6 +180,11 @@ class ProtVistaNavigation extends HTMLElement {
 
   _updateNavRuler() {
     if (this._x) {
+      this._container
+        .style("padding-left", `${this.margin.left}px`)
+        .style("padding-right", `${this.margin.right}px`)
+        .style("padding-top", `${this.margin.top}px`)
+        .style("padding-bottom", `${this.margin.bottom}px`);
       this._x.domain([this._rulerstart, this._rulerstart + this._length]);
       this._axis.call(this._xAxis);
       this._updatePolygon();
@@ -205,12 +211,12 @@ class ProtVistaNavigation extends HTMLElement {
     if (this.polygon)
       this.polygon.attr(
         "points",
-        `${this._x(this._displaystart)},${height / 2}
-        ${this._x(this._displayend)},${height / 2}
-        ${this.width},${height}
-        0,${height}`
+        `${this._x(this._displaystart)},${this.height / 2}
+        ${this._x(this._displayend)},${this.height / 2}
+        ${this.width},${this.height}
+        0,${this.height}`
       );
   }
 }
 
-export default ProtVistaNavigation;
+export default withMargin(ProtVistaNavigation);

--- a/packages/protvista-utils/README.md
+++ b/packages/protvista-utils/README.md
@@ -1,0 +1,37 @@
+# `protvista-utils`
+
+This is a utility package that groups several classes and method that are used by other `protvista` elements.
+
+Here is the description anf reference for the utilities expose in this package.
+
+## `ColorScaleParser`
+
+## `Region`
+
+## `ScrollFilter`
+
+## `withMargin`
+
+It's a way to extend protvista components to include the logic related with dealing with a property margin that follows the shape:
+
+```javascript
+{
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+}
+```
+
+The embedded logic takes care of exposing the following attributes in the webcomponent:
+
+- `margintop`
+- `marginbottom`
+- `marginleft`
+- `marginright`
+
+The attributes are added to the `observedAttributes` of the element, so a change in the dom will trigger the `attributeChangedCallback` method.
+
+The element is also extended to have `getters` and `setters` for properties with the same name.
+
+The approach of this implementations is similar to Higher order components in React.

--- a/packages/protvista-utils/src/index.js
+++ b/packages/protvista-utils/src/index.js
@@ -3,9 +3,11 @@ import _th from "./TrackHighlighter";
 import _csp from "./ColorScaleParser";
 import _s2o from "./String2Object";
 import _sf from "./ScrollFilter";
+import _withMargin from "./withMargin";
 
 export const Region = _Region;
 export const TrackHighlighter = _th;
 export const ColorScaleParser = _csp;
 export const String2Object = _s2o;
 export const ScrollFilter = _sf;
+export const withMargin = _withMargin;

--- a/packages/protvista-utils/src/withMargin.js
+++ b/packages/protvista-utils/src/withMargin.js
@@ -1,0 +1,48 @@
+const sides = ["left", "right", "top", "bottom"];
+const marginSides = sides.map((side) => `margin${side}`);
+
+const withMargin = (
+  Element,
+  options = {
+    initialValue: {
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    },
+  }
+) => {
+  for (const side of sides) {
+    Object.defineProperty(Element.prototype, `margin${side}`, {
+      get() {
+        return this.margin[side] || 0;
+      },
+      set(value) {
+        this.margin[side] = +value;
+      },
+    });
+  }
+
+  class ElementWithMargin extends Element {
+    constructor() {
+      super();
+      this.margin = options.initialValue;
+    }
+
+    static get observedAttributes() {
+      return [...super.observedAttributes, ...marginSides];
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+      if (oldValue !== newValue) {
+        if (marginSides.includes(name)) {
+          this[name] = newValue;
+        }
+      }
+      super.attributeChangedCallback(name, oldValue, newValue);
+    }
+  }
+  return ElementWithMargin;
+};
+
+export default withMargin;

--- a/packages/protvista-utils/src/withMargin.js
+++ b/packages/protvista-utils/src/withMargin.js
@@ -12,17 +12,6 @@ const withMargin = (
     },
   }
 ) => {
-  for (const side of sides) {
-    Object.defineProperty(Element.prototype, `margin${side}`, {
-      get() {
-        return this.margin[side] || 0;
-      },
-      set(value) {
-        this.margin[side] = +value;
-      },
-    });
-  }
-
   class ElementWithMargin extends Element {
     constructor() {
       super();
@@ -41,6 +30,16 @@ const withMargin = (
       }
       super.attributeChangedCallback(name, oldValue, newValue);
     }
+  }
+  for (const side of sides) {
+    Object.defineProperty(ElementWithMargin.prototype, `margin${side}`, {
+      get() {
+        return this.margin[side] || 0;
+      },
+      set(value) {
+        this.margin[side] = +value;
+      },
+    });
   }
   return ElementWithMargin;
 };

--- a/packages/protvista-zoomable/src/protvista-zoomable.js
+++ b/packages/protvista-zoomable/src/protvista-zoomable.js
@@ -2,9 +2,9 @@ import {
   scaleLinear,
   zoom as d3zoom,
   zoomIdentity,
-  event as d3Event
+  event as d3Event,
 } from "d3";
-import { TrackHighlighter, ScrollFilter } from "protvista-utils";
+import { TrackHighlighter, ScrollFilter, withMargin } from "protvista-utils";
 
 import ResizeObserver from "resize-observer-polyfill";
 
@@ -17,7 +17,6 @@ class ProtvistaZoomable extends HTMLElement {
     this.zoomed = this.zoomed.bind(this);
     this._applyZoomTranslation = this.applyZoomTranslation.bind(this);
     this._resetEventHandler = this._resetEventHandler.bind(this);
-    // this.bindEvents = this.bindEvents(this);
     let aboutToApply = false;
     // Postponing the zoom translation to the next frame.
     // This helps in case several attributes are changed almost at the same time,
@@ -35,7 +34,7 @@ class ProtvistaZoomable extends HTMLElement {
     this.trackHighlighter = new TrackHighlighter({ element: this, min: 1 });
 
     this.scrollFilter = new ScrollFilter(this);
-    this.wheelListener = event => this.scrollFilter.wheel(event);
+    this.wheelListener = (event) => this.scrollFilter.wheel(event);
   }
 
   connectedCallback() {
@@ -74,7 +73,7 @@ class ProtvistaZoomable extends HTMLElement {
     this._originXScale = this.xScale.copy();
     this._initZoom();
     this._listenForResize();
-    this.addEventListener("error", e => {
+    this.addEventListener("error", (e) => {
       console.error(e);
     });
     this.addEventListener("click", this._resetEventHandler);
@@ -143,16 +142,6 @@ class ProtvistaZoomable extends HTMLElement {
     return this._svg;
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  get margin() {
-    return {
-      top: 10,
-      right: 10,
-      bottom: 10,
-      left: 10
-    };
-  }
-
   set fixedHighlight(region) {
     this.trackHighlighter.setFixedHighlight(region);
   }
@@ -173,11 +162,11 @@ class ProtvistaZoomable extends HTMLElement {
       .scaleExtent([1, Infinity])
       .translateExtent([
         [0, 0],
-        [this.getWidthWithMargins(), 0]
+        [this.getWidthWithMargins(), 0],
       ])
       .extent([
         [0, 0],
-        [this.getWidthWithMargins(), 0]
+        [this.getWidthWithMargins(), 0],
       ])
       .filter(() => {
         if (!(d3Event instanceof WheelEvent)) return true;
@@ -232,10 +221,10 @@ class ProtvistaZoomable extends HTMLElement {
           displayend: Math.min(
             this.length,
             Math.max(end - 1, start + 1) // To make sure it never zooms in deeper than showing 2 bases covering the full width
-          )
+          ),
         },
         bubbles: true,
-        cancelable: true
+        cancelable: true,
       })
     );
   }
@@ -269,7 +258,7 @@ class ProtvistaZoomable extends HTMLElement {
     if (this.svg) this.svg.attr("width", this.width);
     this._zoom.scaleExtent([1, Infinity]).translateExtent([
       [0, 0],
-      [this.getWidthWithMargins(), 0]
+      [this.getWidthWithMargins(), 0],
     ]);
     this.applyZoomTranslation();
   }
@@ -314,7 +303,7 @@ class ProtvistaZoomable extends HTMLElement {
     }
 
     if (!Element.prototype.closest) {
-      Element.prototype.closest = s => {
+      Element.prototype.closest = (s) => {
         let el = this;
 
         do {
@@ -345,12 +334,12 @@ class ProtvistaZoomable extends HTMLElement {
       eventtype: type,
       coords: ProtvistaZoomable._getClickCoords(),
       feature,
-      target
+      target,
     };
     if (withHighlight) {
       if (feature && feature.fragments) {
         detail.highlight = feature.fragments
-          .map(fr => `${fr.start}:${fr.end}`)
+          .map((fr) => `${fr.start}:${fr.end}`)
           .join(",");
       } else if (d3Event && d3Event.shiftKey && this._highlight) {
         // If holding shift, add to the highlights
@@ -365,7 +354,7 @@ class ProtvistaZoomable extends HTMLElement {
     return new CustomEvent("change", {
       detail,
       bubbles: true,
-      cancelable: true
+      cancelable: true,
     });
   }
 
@@ -410,4 +399,11 @@ class ProtvistaZoomable extends HTMLElement {
   }
 }
 
-export default ProtvistaZoomable;
+export default withMargin(ProtvistaZoomable, {
+  initialValue: {
+    top: 10,
+    right: 10,
+    bottom: 10,
+    left: 10,
+  },
+});


### PR DESCRIPTION
### Reference to issue
FIX #109 

### Description of changes
It creates a higher order component that embeds the logic for a margin object. it exposes the following attributes and parameters:
* `marginleft`
* `marginright`
* `margintop`
* `marginbottom`

### Tests / Styleguide
 - [x] Tests pass
 - [x] Styleguide
