### PR TITLE
Hackathon 2020 track tests

### DIFF
--- a/app/src/components/ProtvistaColouredSequence.jsx
+++ b/app/src/components/ProtvistaColouredSequence.jsx
@@ -45,8 +45,7 @@ class ProtvistaColouredSequenceWrapper extends Component {
           height="10"
           displaystart="50"
           displayend="70"
-          highlightStart="23"
-          highlightEnd="45"
+          highlight="23:45"
           scale="hydrophobicity-scale"
         />
         <protvista-coloured-sequence

--- a/app/src/components/ProtvistaNavigation.jsx
+++ b/app/src/components/ProtvistaNavigation.jsx
@@ -13,8 +13,7 @@ const ProtvistaNavigationWrapper = (props) => {
         length="456"
         displaystart="143"
         displayend="400"
-        highlightStart="23"
-        highlightEnd="45"
+        highlight="23:45"
         rulerstart="50"
       />
     </Fragment>

--- a/app/src/components/ProtvistaSequence.jsx
+++ b/app/src/components/ProtvistaSequence.jsx
@@ -31,32 +31,28 @@ class ProtvistaSequenceWrapper extends Component {
           length="223"
           displaystart="10"
           displayend="150"
-          highlightStart="23"
-          highlightEnd="45"
+          highlight="23:45"
         />
         <protvista-sequence
           id="seq3"
           length="223"
           displaystart="18"
           displayend="100"
-          highlightStart="23"
-          highlightEnd="45"
+          highlight="23:45"
         />
         <protvista-sequence
           id="seq4"
           length="223"
           displaystart="22"
           displayend="50"
-          highlightStart="23"
-          highlightEnd="45"
+          highlight="23:45"
         />
         <protvista-sequence
           sequence="MAMYDDEFDTKASDLTFSPWVEVENWKDVTTRLRAIKFALQADRDKIPGVLSDLKTNCPYSAFKRFPDKSLYSVLSKEAVIAVAQIQSASGFKRRADEKNAVSGLVSVTPTQISQSASSSAATPVGLATVKPPRESDSAFQEDTFSYAKFDDASTAFHKALAYLEGLSLRPTYRRKFEKDMNVKWGGSGSAPSGAPAGGSSGSAPPTSGSSGSGAAPTPPPNP"
           length="223"
           displaystart="1"
           displayend="4"
-          highlightStart="2"
-          highlightEnd="2"
+          highlight="23:45"
         />
       </Fragment>
     );

--- a/app/src/components/examples.js
+++ b/app/src/components/examples.js
@@ -4,7 +4,7 @@ const elements = {
   clear: {
     name: "clear",
     codeSample: "",
-    dataSample: ""
+    dataSample: "",
   },
   "protvista-navigation": {
     name: "protvista-navigation",
@@ -14,7 +14,7 @@ const elements = {
           length="223" 
           displaystart="1" 
           displayend="223" 
-      />`
+      />`,
   },
   "protvista-track": {
     name: "protvista-track",
@@ -24,13 +24,12 @@ const elements = {
           width="1020" 
           length="223" 
           displaystart="1" 
-          displayend="223" 
-          highlightstart="23" 
-          highlightend="45"
+          displayend="223"
+          highlight="23:45" 
           color="red"
       />`,
     dataType: "json",
-    dataSample: data
+    dataSample: data,
   },
   "protvista-sequence": {
     name: "protvista-sequence",
@@ -41,13 +40,12 @@ const elements = {
           length="223" 
           displaystart="1" 
           displayend="223" 
-          highlightstart="23" 
-          highlightend="45"
+          highlight="23:45"
        />`,
     dataType: "string",
     dataSample:
-      "MAMYDDEFDTKASDLTFSPWVEVENWKDVTTRLRAIKFALQADRDKIPGVLSDLKTNCPYSAFKRFPDKSLYSVLSKEAVIAVAQIQSASGFKRRADEKNAVSGLVSVTPTQISQSASSSAATPVGLATVKPPRESDSAFQEDTFSYAKFDDASTAFHKALAYLEGLSLRPTYRRKFEKDMNVKWGGSGSAPSGAPAGGSSGSAPPTSGSSGSGAAPTPPPNP"
-  }
+      "MAMYDDEFDTKASDLTFSPWVEVENWKDVTTRLRAIKFALQADRDKIPGVLSDLKTNCPYSAFKRFPDKSLYSVLSKEAVIAVAQIQSASGFKRRADEKNAVSGLVSVTPTQISQSASSSAATPVGLATVKPPRESDSAFQEDTFSYAKFDDASTAFHKALAYLEGLSLRPTYRRKFEKDMNVKWGGSGSAPSGAPAGGSSGSAPPTSGSSGSGAAPTPPPNP",
+  },
 };
 
 export default elements;

--- a/packages/protvista-interpro-track/README.md
+++ b/packages/protvista-interpro-track/README.md
@@ -26,12 +26,10 @@ The start position of the selected region.
 
 The end position of the selected region.
 
-#### `highlightStart: number (optional)`
+#### `highlight: string (optional)`
 
-The start position of the highlighted region.
+A comma separated list of regions to highlight.
 
-#### `highlightEnd: number (optional)`
-
-The end position of the highlighted region.
+Each region follows the format: `[start]:[end]`, where both `[start]` and `[end]` are optional numbers.
 
 ### Events

--- a/packages/protvista-interpro-track/examples/index.html
+++ b/packages/protvista-interpro-track/examples/index.html
@@ -22,7 +22,7 @@
             <protvista-interpro-track
               id= "track1" length="466"
               displaystart="1" displayend="466"
-              highlightstart="23" highlightend="45"
+              highlight="23:45"
               color="red" shape="roundRectangle" expanded>
             </protvista-track>
           </td>
@@ -33,7 +33,7 @@
             <protvista-interpro-track
               id= "track2" length="466"
               displaystart="1" displayend="466"
-              highlightstart="23" highlightend="45"
+              highlight="23:45"
               color="red" expanded>
             </protvista-track>
           </td>
@@ -44,7 +44,7 @@
             <protvista-interpro-track
               id= "track3" length="466"
               displaystart="1" displayend="466"
-              highlightstart="23" highlightend="45"
+              highlight="23:45"
               color="cornflowerblue" expanded>
             </protvista-track>
           </td>
@@ -55,7 +55,7 @@
             <protvista-interpro-track
               id= "track4" length="4"
               displaystart="2" displayend="4"
-              highlightstart="3" highlightend="3"
+              highlight="23:45"
               color="cornflowerblue" shape="roundRectangle" expanded>
             </protvista-track>
           </td>

--- a/packages/protvista-interpro-track/index.html
+++ b/packages/protvista-interpro-track/index.html
@@ -11,10 +11,10 @@
     <!-- Place favicon.ico in the root directory -->
   </head>
   <body>
-    <table style="width:  100%;">
+    <table style="width: 100%">
       <tr>
         <th>FROM</th>
-        <th style="width:  90%;">Track</th>
+        <th style="width: 90%">Track</th>
         <th>TO</th>
       </tr>
       <tr>
@@ -25,8 +25,7 @@
             length="223"
             displaystart="1"
             displayend="223"
-            highlightstart="23"
-            highlightend="45"
+            highlight="23:45"
             color="red"
           ></protvista-interpro-track>
         </td>
@@ -40,8 +39,7 @@
             length="223"
             displaystart="1"
             displayend="223"
-            highlightstart="23"
-            highlightend="45"
+            highlight="23:45"
             color="green"
             expanded
           ></protvista-interpro-track>
@@ -56,8 +54,7 @@
             length="223"
             displaystart="110"
             displayend="210"
-            highlightstart="23"
-            highlightend="45"
+            highlight="23:45"
           ></protvista-interpro-track>
         </td>
         <td>210</td>
@@ -102,17 +99,17 @@
           {
             accession: "feature2",
             locations: [{ fragments: [{ start: 50, end: 160 }] }],
-            color: "#A42ea2"
+            color: "#A42ea2",
           },
           {
             accession: "feature3",
             locations: [
               {
-                fragments: [{ start: 155, end: 155 }]
+                fragments: [{ start: 155, end: 155 }],
               },
-              { fragments: [{ start: 158, end: 158 }] }
+              { fragments: [{ start: 158, end: 158 }] },
             ],
-            color: "#A4Aea2"
+            color: "#A4Aea2",
           },
           {
             accession: "feature4",
@@ -120,11 +117,11 @@
               {
                 fragments: [
                   { start: 200, end: 204 },
-                  { start: 206, end: 210 }
-                ]
-              }
-            ]
-          }
+                  { start: 206, end: 210 },
+                ],
+              },
+            ],
+          },
         ];
         const contributors = [
           {
@@ -140,19 +137,19 @@
                     fragments: [
                       { start: 20, end: 20, residue: "G" },
                       { start: 25, end: 25, residue: "A" },
-                      { start: 30, end: 30, residue: "S" }
-                    ]
+                      { start: 30, end: 30, residue: "S" },
+                    ],
                   },
                   {
                     description: "flexible hinge region",
                     fragments: [
                       { start: 22, end: 22, residue: "T" },
-                      { start: 24, end: 24, residue: "G" }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      { start: 24, end: 24, residue: "G" },
+                    ],
+                  },
+                ],
+              },
+            ],
           },
           {
             accession: "feature1.2",
@@ -160,10 +157,10 @@
               {
                 fragments: [
                   { start: 10, end: 27 },
-                  { start: 29, end: 40 }
-                ]
-              }
-            ]
+                  { start: 29, end: 40 },
+                ],
+              },
+            ],
           },
           { accession: "feature2.1", start: 50, end: 160 },
           {
@@ -173,10 +170,10 @@
                 fragments: [
                   { start: 50, end: 94 },
                   { start: 99, end: 110 },
-                  { start: 116, end: 158 }
-                ]
-              }
-            ]
+                  { start: 116, end: 158 },
+                ],
+              },
+            ],
           },
           {
             accession: "feature2.3",
@@ -184,18 +181,18 @@
               {
                 fragments: [
                   { start: 52, end: 98 },
-                  { start: 104, end: 160 }
-                ]
-              }
-            ]
+                  { start: 104, end: 160 },
+                ],
+              },
+            ],
           },
           {
             accession: "feature3.1",
             locations: [
               { fragments: [{ start: 155, end: 155 }] },
-              { fragments: [{ start: 158, end: 158 }] }
-            ]
-          }
+              { fragments: [{ start: 158, end: 158 }] },
+            ],
+          },
         ];
         document.querySelector("#track1").data = data;
         document.querySelector("#track2").data = data;

--- a/packages/protvista-manager/examples/index.html
+++ b/packages/protvista-manager/examples/index.html
@@ -20,8 +20,7 @@
         length="223"
         displaystart="120"
         displayend="158"
-        highlightStart="10"
-        highlightEnd="45"
+        highlight="10:45"
       ></protvista-navigation>
       <protvista-sequence
         id="seq1"
@@ -48,8 +47,7 @@
         length="223"
         displaystart="120"
         displayend="158"
-        highlightstart="10"
-        highlightend="45"
+        highlight="10:45"
         layout="non-overlapping"
       ></protvista-track>
       <protvista-interpro-track
@@ -57,8 +55,7 @@
         length="223"
         displaystart="120"
         displayend="158"
-        highlightstart="10"
-        highlightend="45"
+        highlight="10:45"
       ></protvista-interpro-track>
       <protvista-tooltip id="my_tooltip" />
     </protvista-manager>
@@ -142,21 +139,29 @@
                 accession: "feature1.2",
                 locations: [
                   {
-                    fragments: [{ start: 10, end: 27 }, { start: 29, end: 40 }]
-                  }
-                ]
-              }
-            ]
+                    fragments: [
+                      { start: 10, end: 27 },
+                      { start: 29, end: 40 },
+                    ],
+                  },
+                ],
+              },
+            ],
           },
           { accession: "feature2", start: 30, end: 150, color: "#A42ea2" },
           { accession: "feature3", start: 155, end: 155, color: "#A4Aea2" },
           {
             accession: "feature4",
             locations: [
-              { fragments: [{ start: 2, end: 3 }, { start: 5, end: 5 }] }
+              {
+                fragments: [
+                  { start: 2, end: 3 },
+                  { start: 5, end: 5 },
+                ],
+              },
             ],
-            color: "#34Aea2"
-          }
+            color: "#34Aea2",
+          },
         ];
         // document.querySelector("#track1").data = data;
         document.querySelector("#track2").data = data;
@@ -174,25 +179,30 @@
                     fragments: [
                       { start: 20, end: 20, residue: "G" },
                       { start: 25, end: 25, residue: "A" },
-                      { start: 30, end: 30, residue: "S" }
-                    ]
+                      { start: 30, end: 30, residue: "S" },
+                    ],
                   },
                   {
                     description: "flexible hinge region",
                     fragments: [
                       { start: 22, end: 22, residue: "T" },
-                      { start: 24, end: 24, residue: "G" }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      { start: 24, end: 24, residue: "G" },
+                    ],
+                  },
+                ],
+              },
+            ],
           },
           {
             accession: "feature1.2",
             locations: [
-              { fragments: [{ start: 10, end: 27 }, { start: 29, end: 40 }] }
-            ]
+              {
+                fragments: [
+                  { start: 10, end: 27 },
+                  { start: 29, end: 40 },
+                ],
+              },
+            ],
           },
           { accession: "feature2.1", start: 50, end: 160 },
           {
@@ -202,16 +212,21 @@
                 fragments: [
                   { start: 50, end: 94 },
                   { start: 99, end: 110 },
-                  { start: 116, end: 158 }
-                ]
-              }
-            ]
+                  { start: 116, end: 158 },
+                ],
+              },
+            ],
           },
           {
             accession: "feature2.3",
             locations: [
-              { fragments: [{ start: 52, end: 98 }, { start: 104, end: 160 }] }
-            ]
+              {
+                fragments: [
+                  { start: 52, end: 98 },
+                  { start: 104, end: 160 },
+                ],
+              },
+            ],
           },
           {
             accession: "feature3.1",
@@ -219,17 +234,17 @@
               {
                 fragments: [
                   { start: 155, end: 155, shape: "discontinuosEnd" },
-                  { start: 158, end: 158, shape: "discontinuosStart" }
-                ]
-              }
-            ]
-          }
+                  { start: 158, end: 158, shape: "discontinuosStart" },
+                ],
+              },
+            ],
+          },
         ];
 
         document.querySelector("#track3").data = data;
         document.querySelector("#track3").contributors = contributors;
 
-        document.addEventListener("change", e => {
+        document.addEventListener("change", (e) => {
           const { detail } = e;
           const tooltip = document.getElementById("my_tooltip");
           if (detail.eventtype === "click") {

--- a/packages/protvista-manager/index.html
+++ b/packages/protvista-manager/index.html
@@ -26,8 +26,6 @@
         displaystart="1"
         displayend="158"
       ></protvista-sequence>
-      <!-- <protvista-track id="track1" length="223" displaystart="1" displayend="158" highlightstart="10" highlightend="45"></protvista-track>
-        <protvista-track id="track2" length="223" displaystart="1" displayend="158" highlightstart="10" highlightend="45" layout="non-overlapping"></protvista-track> -->
       <protvista-track
         id="track1"
         length="770"
@@ -142,12 +140,12 @@
                   {
                     fragments: [
                       { start: 10, end: 27 },
-                      { start: 29, end: 40 }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      { start: 29, end: 40 },
+                    ],
+                  },
+                ],
+              },
+            ],
           },
           { accession: "feature2", start: 30, end: 150, color: "#A42ea2" },
           { accession: "feature3", start: 155, end: 155, color: "#A4Aea2" },
@@ -157,12 +155,12 @@
               {
                 fragments: [
                   { start: 2, end: 3 },
-                  { start: 5, end: 5 }
-                ]
-              }
+                  { start: 5, end: 5 },
+                ],
+              },
             ],
-            color: "#34Aea2"
-          }
+            color: "#34Aea2",
+          },
         ];
         document.querySelector("#track1").data = data;
         document.querySelector("#track2").data = data;

--- a/packages/protvista-navigation/README.md
+++ b/packages/protvista-navigation/README.md
@@ -13,8 +13,7 @@ This custom element can be used to zoom and navigate along the sequence displaye
   length="456"
   displaystart="143"
   displayend="400"
-  highlightStart="23"
-  highlightEnd="45"
+  highlight="23:45"
   rulerstart="50"
 />
 ```
@@ -33,13 +32,11 @@ The start position of the selected region.
 
 The end position of the selected region.
 
-#### `highlightStart: number (optional)`
+#### `highlight: string (optional)`
 
-The start position of the highlighted region.
+A comma separated list of regions to highlight.
 
-#### `highlightEnd: number (optional)`
-
-The end position of the highlighted region.
+Each region follows the format: `[start]:[end]`, where both `[start]` and `[end]` are optional numbers.
 
 #### `rulerstart: number (optional)`
 

--- a/packages/protvista-navigation/src/protvista-navigation.js
+++ b/packages/protvista-navigation/src/protvista-navigation.js
@@ -37,8 +37,6 @@ class ProtVistaNavigation extends HTMLElement {
     this._displaystart = parseFloat(this.getAttribute("displaystart")) || 1;
     this._displayend =
       parseFloat(this.getAttribute("displayend")) || this._length;
-    this._highlightStart = parseFloat(this.getAttribute("highlightStart"));
-    this._highlightEnd = parseFloat(this.getAttribute("highlightEnd"));
     this._rulerstart = parseFloat(this.getAttribute("rulerStart")) || 1;
 
     this._onResize = this._onResize.bind(this);
@@ -57,15 +55,7 @@ class ProtVistaNavigation extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return [
-      "length",
-      "displaystart",
-      "displayend",
-      "highlightStart",
-      "highlightEnd",
-      "width",
-      "rulerstart",
-    ];
+    return ["length", "displaystart", "displayend", "width", "rulerstart"];
   }
 
   attributeChangedCallback(name, oldValue, newValue) {

--- a/packages/protvista-sequence/src/protvista-sequence.js
+++ b/packages/protvista-sequence/src/protvista-sequence.js
@@ -11,16 +11,9 @@ class ProtVistaSequence extends ProtvistaZoomable {
     if (this.sequence) {
       this._createSequence();
     }
-    this.addEventListener("load", e => {
+    this.addEventListener("load", (e) => {
       this.data = e.detail.payload;
     });
-  }
-
-  static get observedAttributes() {
-    return ProtvistaZoomable.observedAttributes.concat(
-      "highlightstart",
-      "highlightend"
-    );
   }
 
   get data() {
@@ -102,7 +95,7 @@ class ProtVistaSequence extends ProtvistaZoomable {
       // only add axis if there is room
       if (this.height > this.chHeight) {
         this.xAxis = axisBottom(this.xScale)
-          .tickFormat(d => (Number.isInteger(d) ? d : ""))
+          .tickFormat((d) => (Number.isInteger(d) ? d : ""))
           .ticks(NUMBER_OF_TICKS, "s");
         this.axis.call(this.xAxis);
       }
@@ -111,24 +104,26 @@ class ProtVistaSequence extends ProtvistaZoomable {
       this.axis.select(".domain").remove();
       this.axis.selectAll(".tick line").remove();
 
-      this.bases = this.seq_g.selectAll("text.base").data(bases, d => d.start);
+      this.bases = this.seq_g
+        .selectAll("text.base")
+        .data(bases, (d) => d.start);
       this.bases
         .enter()
         .append("text")
         .attr("class", "base")
         .attr("text-anchor", "middle")
-        .attr("x", d => this.getXFromSeqPosition(d.start) + half)
-        .text(d => d.aa)
+        .attr("x", (d) => this.getXFromSeqPosition(d.start) + half)
+        .text((d) => d.aa)
         .style("pointer-events", "none")
         .style("font-family", "monospace");
 
       this.bases.exit().remove();
 
-      this.bases.attr("x", d => this.getXFromSeqPosition(d.start) + half);
+      this.bases.attr("x", (d) => this.getXFromSeqPosition(d.start) + half);
 
       this.background = this.seq_bg
         .selectAll("rect.base_bg")
-        .data(bases, d => d.start);
+        .data(bases, (d) => d.start);
       this.background
         .enter()
         .append("rect")
@@ -136,10 +131,10 @@ class ProtVistaSequence extends ProtvistaZoomable {
         .attr("height", this._height)
         .merge(this.background)
         .attr("width", ftWidth)
-        .attr("fill", d => {
+        .attr("fill", (d) => {
           return Math.round(d.start) % 2 ? "#ccc" : "#eee";
         })
-        .attr("x", d => this.getXFromSeqPosition(d.start))
+        .attr("x", (d) => this.getXFromSeqPosition(d.start))
         .call(this.bindEvents, this);
       this.background.exit().remove();
 

--- a/packages/protvista-sequence/tests/__snapshots__/protvista-sequence.test.js.snap
+++ b/packages/protvista-sequence/tests/__snapshots__/protvista-sequence.test.js.snap
@@ -88,7 +88,7 @@ exports[`protvista-sequence tests it should display the sequence correctly 1`] =
 
 exports[`protvista-sequence tests it should display the sequence correctly after highlight 1`] = `
 <protvista-sequence
-  highlightstart="4"
+  highlight="2:4"
   length="15"
   sequence="MAMYDDEFDTKASDL"
   style="display: block; width: 100%;"
@@ -164,8 +164,8 @@ exports[`protvista-sequence tests it should display the sequence correctly after
           fill="rgba(255, 235, 59, 0.8)"
           height="44"
           style="opacity: 0.5; pointer-events: none;"
-          width="21.333333333333332"
-          x="10"
+          width="16"
+          x="15.333333333333332"
         />
       </g>
     </svg>

--- a/packages/protvista-sequence/tests/protvista-sequence.test.js
+++ b/packages/protvista-sequence/tests/protvista-sequence.test.js
@@ -31,8 +31,7 @@ describe("protvista-sequence tests", () => {
   });
 
   test("it should display the sequence correctly after highlight", (done) => {
-    rendered.setAttribute("highlightstart", "2");
-    rendered.setAttribute("highlightstart", "4");
+    rendered.setAttribute("highlight", "2:4");
     window.requestAnimationFrame(() => {
       expect(rendered).toMatchSnapshot();
       done();

--- a/packages/protvista-track/src/NonOverlappingLayout.js
+++ b/packages/protvista-track/src/NonOverlappingLayout.js
@@ -8,7 +8,7 @@ const featuresOverlap = (feature1, feature2) => {
 };
 
 const featureOvelapsInRow = (feature, row) => {
-  return row.some(rowFeature => featuresOverlap(feature, rowFeature));
+  return row.some((rowFeature) => featuresOverlap(feature, rowFeature));
 };
 
 export default class NonOverlappingLayout extends DefaultLayout {
@@ -21,9 +21,9 @@ export default class NonOverlappingLayout extends DefaultLayout {
   }
 
   init(features) {
-    features.forEach(feature => {
+    features.forEach((feature) => {
       const rowIndex = this._rows.findIndex(
-        row => !featureOvelapsInRow(feature, row)
+        (row) => !featureOvelapsInRow(feature, row)
       );
       if (rowIndex >= 0) {
         this._rows[rowIndex].push(feature);

--- a/packages/protvista-track/src/protvista-track.js
+++ b/packages/protvista-track/src/protvista-track.js
@@ -144,6 +144,9 @@ class ProtvistaTrack extends ProtvistaZoomable {
   }
 
   _createTrack() {
+    if (!this._data) {
+      return;
+    }
     this._layoutObj.init(this._data);
 
     select(this).selectAll("div").remove();

--- a/packages/protvista-track/src/protvista-track.js
+++ b/packages/protvista-track/src/protvista-track.js
@@ -11,8 +11,11 @@ import DefaultLayout from "./DefaultLayout";
 import { getShapeByType, getColorByType } from "./ConfigHelper";
 
 class ProtvistaTrack extends ProtvistaZoomable {
-  getLayout() {
-    if (String(this.getAttribute("layout")).toLowerCase() === "non-overlapping")
+  getLayout(layout) {
+    if (
+      layout === "non-overlapping" ||
+      String(this.getAttribute("layout")).toLowerCase() === "non-overlapping"
+    )
       return new NonOverlappingLayout({
         layoutHeight: this._height,
       });
@@ -76,11 +79,20 @@ class ProtvistaTrack extends ProtvistaZoomable {
 
   static get observedAttributes() {
     return ProtvistaZoomable.observedAttributes.concat([
-      "highlight",
       "color",
       "shape",
       "filters",
+      "layout",
     ]);
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+    if (name === "layout") {
+      this._applyFilters();
+      this._layoutObj = this.getLayout();
+      this._createTrack();
+    }
   }
 
   _getFeatureColor(f) {

--- a/packages/protvista-track/tests/__snapshots__/protvista-track.test.js.snap
+++ b/packages/protvista-track/tests/__snapshots__/protvista-track.test.js.snap
@@ -1,0 +1,4013 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`protvista-track tests it should change the layout 1`] = `
+<protvista-track
+  layout="non-overlapping"
+  length="223"
+  style="display: block; width: 100%;"
+>
+  <div
+    style="line-height: 0;"
+  >
+    <svg
+      height="44"
+      width="100"
+    >
+      <g
+        class="highlighted"
+      >
+        <rect
+          fill="rgba(255, 235, 59, 0.8)"
+          height="44"
+          style="opacity: 0.5; pointer-events: none;"
+          width="0"
+          x="10"
+        />
+      </g>
+      <g
+        class="sequence-features"
+      >
+        <g
+          class="feature-group"
+          id="g_feature1"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L11.121076233183857,0L11.121076233183857,-0.5806451612903225L0,-0.5806451612903225Z"
+                fill="#342ea2"
+                stroke="#342ea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(13.228699551569507,2)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(13.228699551569507,2)"
+                width="11.121076233183857"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature2"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L39.82062780269058,0L39.82062780269058,-0.5806451612903225L0,-0.5806451612903225Z"
+                fill="#A42ea2"
+                stroke="#A42ea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(27.57847533632287,3.4193548387096775)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(27.57847533632287,3.4193548387096775)"
+                width="39.82062780269058"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature3"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L0.35874439461883406,0L0.35874439461883406,-0.5806451612903225L0,-0.5806451612903225Z"
+                fill="#A4Aea2"
+                stroke="#A4Aea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(65.24663677130044,4.838709677419355)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(65.24663677130044,4.838709677419355)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L0.35874439461883406,0L0.35874439461883406,-0.5806451612903225L0,-0.5806451612903225Z"
+                fill="#A4Aea2"
+                stroke="#A4Aea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(66.32286995515696,4.838709677419355)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(66.32286995515696,4.838709677419355)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature4"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.7937219730941703,0L1.7937219730941703,-0.5806451612903225L0,-0.5806451612903225Z"
+                fill="black"
+                stroke="black"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(81.39013452914799,6.258064516129032)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(81.39013452914799,6.258064516129032)"
+                width="1.7937219730941703"
+              />
+            </g>
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.7937219730941703,0L1.7937219730941703,-0.5806451612903225L0,-0.5806451612903225Z"
+                fill="black"
+                stroke="black"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(83.54260089686099,6.258064516129032)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(83.54260089686099,6.258064516129032)"
+                width="1.7937219730941703"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature1"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.0762331838565022,0L1.0762331838565022,-0.5806451612903225L0,-0.5806451612903225Z"
+                fill="#339"
+                stroke="#339"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,2)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,2)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature5"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.0762331838565022,0L1.0762331838565022,-0.5806451612903225L0,-0.5806451612903225Z"
+                fill="#63e"
+                stroke="#63e"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,7.67741935483871)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,7.67741935483871)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature6"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.0762331838565022,0L1.0762331838565022,-0.5806451612903225L0,-0.5806451612903225Z"
+                fill="#35d"
+                stroke="#35d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,9.096774193548388)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,9.096774193548388)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature6_2"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="line feature"
+                d="M0,-0.29032258064516125 L1.0762331838565022,-0.29032258064516125"
+                fill="#35d"
+                stroke="#35d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,10.516129032258064)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,10.516129032258064)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature7"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="bridge feature"
+                d="M0,-0.5806451612903225L0,-0.29032258064516125L0.17937219730941703,-0.29032258064516125L0.17937219730941703,0L0.17937219730941703,-0.29032258064516125L0.35874439461883406,-0.29032258064516125L0.35874439461883406,-0.5806451612903225Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,11.935483870967742)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,11.935483870967742)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature8"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="bridge feature"
+                d="M0,-0.5806451612903225L0,0L0.7174887892376681,0L0.7174887892376681,-0.5806451612903225L0.7174887892376681,2L0,2Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,13.35483870967742)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,13.35483870967742)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature9"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="diamond feature"
+                d="M0.17937219730941703,0L5.179372197309417,5L0.17937219730941703,10L-4.820627802690583,5Z"
+                fill="#33d"
+                stroke="#33d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14.774193548387098)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14.774193548387098)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature10"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="diamond feature"
+                d="M0.35874439461883406,0L5.358744394618834,5L0.35874439461883406,10L-4.641255605381166,5M0,5L0.7174887892376681,5Z"
+                fill="#33d"
+                stroke="#33d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,16.193548387096776)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,16.193548387096776)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature11"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="chevron feature"
+                d="M0.17937219730941703,5L5.179372197309417,0L5.179372197309417,5L0.17937219730941703,10L-4.820627802690583,5L-4.820627802690583,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,17.612903225806452)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,17.612903225806452)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature12"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="chevron feature"
+                d="M0.35874439461883406,5L5.358744394618834,0L5.358744394618834,5L0.35874439461883406,10L-4.641255605381166,5L-4.641255605381166,0L0.35874439461883406,5M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,19.032258064516128)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,19.032258064516128)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature13"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="catFace feature"
+                d="M-4.820627802690583,0L-4.820627802690583,6L-1.8206278026905829,10L2.179372197309417,10L5.179372197309417,6L5.179372197309417,0L2.179372197309417,4L-1.8206278026905829,4Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,20.451612903225808)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,20.451612903225808)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature14"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="catFace feature"
+                d="M-4.641255605381166,0L-4.641255605381166,6L-1.641255605381166,10L2.3587443946188342,10L5.358744394618834,6L5.358744394618834,0L2.3587443946188342,4L-1.641255605381166,4M0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,21.870967741935484)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,21.870967741935484)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature15"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="triangle feature"
+                d="M0.17937219730941703,0L5.179372197309417,10L-4.820627802690583,10Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,23.290322580645164)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,23.290322580645164)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature16"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="triangle feature"
+                d="M0.35874439461883406,0L5.358744394618834,10L-4.641255605381166,10L0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,24.70967741935484)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,24.70967741935484)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature17"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="wave feature"
+                d="M-4.820627802690583,5A2.5,5 0 1,1 0.17937219730941703,5A2.5,5 0 1,0 5.179372197309417,5Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,26.129032258064516)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,26.129032258064516)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature18"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="wave feature"
+                d="M-4.641255605381166,5A2.5,5 0 1,1 0.35874439461883406,5A2.5,5 0 1,0 5.358744394618834,5M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,27.548387096774196)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,27.548387096774196)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature15"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="hexagon feature"
+                d="M 5.179372197309417,5 2.6793721973094176,9.330127018922193 -2.320627802690582,9.330127018922195 -4.820627802690583,5.000000000000001 -2.320627802690585,0.6698729810778072 2.6793721973094176,0.6698729810778072 Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,28.967741935483872)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,28.967741935483872)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature16"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="hexagon feature"
+                d="M 5.358744394618834,5 2.8587443946188347,9.330127018922193 -2.141255605381165,9.330127018922195 -4.641255605381166,5.000000000000001 -2.141255605381168,0.6698729810778072 2.8587443946188347,0.6698729810778072  5.358744394618834,5 M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,30.38709677419355)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,30.38709677419355)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature17"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="pentagon feature"
+                d="M 5.179372197309417,5 1.7244571691841544,9.755282581475768 -3.8657127745653193,7.938926261462367 -3.86571277456532,2.061073738537635 1.7244571691841533,0.2447174185242318 Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,31.806451612903228)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,31.806451612903228)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature18"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="pentagon feature"
+                d="M 5.358744394618834,5 1.9038293664935713,9.755282581475768 -3.686340577255902,7.938926261462367 -3.686340577255903,2.061073738537635 1.9038293664935702,0.2447174185242318  5.358744394618834,5 M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,33.225806451612904)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,33.225806451612904)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature19"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="circle feature"
+                d="M0.17937219730941703,0A1.7841241161527712,1.7841241161527712 0 1,1 0.17937219730941703,10A1.7841241161527712,1.7841241161527712 0 1,1 0.17937219730941703,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,34.645161290322584)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,34.645161290322584)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature20"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="circle feature"
+                d="M0.35874439461883406,0A1.7841241161527712,1.7841241161527712 0 1,1 0.35874439461883406,10A1.7841241161527712,1.7841241161527712 0 1,1 0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,36.064516129032256)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,36.064516129032256)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature21"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="arrow feature"
+                d="M0.17937219730941703,0L-0.820627802690583,0L-4.820627802690583,4L-0.820627802690583,-0.5806451612903225L0.17937219730941703,-0.5806451612903225L4.179372197309417,4Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,37.483870967741936)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,37.483870967741936)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature22"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="arrow feature"
+                d="M0.35874439461883406,0L-0.641255605381166,0L-4.641255605381166,4L-0.641255605381166,-0.5806451612903225L0.35874439461883406,-0.5806451612903225L4.358744394618834,4L0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,38.903225806451616)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,38.903225806451616)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature19"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="doubleBar feature"
+                d="M0.17937219730941703,0L-4.820627802690583,10L0.17937219730941703,10L5.179372197309417,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,40.322580645161295)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,40.322580645161295)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature20"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="doubleBar feature"
+                d="M0.35874439461883406,0L-4.641255605381166,10L0.35874439461883406,10L5.358744394618834,0L0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,41.74193548387097)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,41.74193548387097)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature21"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="helix feature"
+                d=""
+                fill="transparent"
+                stroke="#f06"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,43.16129032258065)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10,43.16129032258065)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature22"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="strand feature"
+                d="M0,-0.14516129032258063L0,-0.14516129032258063L0,-0.4354838709677419L0,-0.4354838709677419L0,-0.14516129032258063M0,0L0.35874439461883406,-0.29032258064516125L0,-0.5806451612903225Z"
+                fill="#fc0"
+                stroke="#fc0"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,44.58064516129033)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="-0.5806451612903225"
+                stroke="transparent"
+                transform="translate(10.358744394618833,44.58064516129033)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+</protvista-track>
+`;
+
+exports[`protvista-track tests it should display the sequence correctly after highlight 1`] = `
+<protvista-track
+  highlight="10:30"
+  length="223"
+  style="display: block; width: 100%;"
+>
+  <div
+    style="line-height: 0;"
+  >
+    <svg
+      height="44"
+      width="100"
+    >
+      <g
+        class="highlighted"
+      >
+        <rect
+          fill="rgba(255, 235, 59, 0.8)"
+          height="44"
+          style="opacity: 0.5; pointer-events: none;"
+          width="7.533632286995515"
+          x="13.228699551569507"
+        />
+      </g>
+      <g
+        class="sequence-features"
+      >
+        <g
+          class="feature-group"
+          id="g_feature1"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L11.121076233183857,0L11.121076233183857,16L0,16Z"
+                fill="#342ea2"
+                stroke="#342ea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(13.228699551569507,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(13.228699551569507,14)"
+                width="11.121076233183857"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature2"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L39.82062780269058,0L39.82062780269058,16L0,16Z"
+                fill="#A42ea2"
+                stroke="#A42ea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(27.57847533632287,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(27.57847533632287,14)"
+                width="39.82062780269058"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature3"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L0.35874439461883406,0L0.35874439461883406,16L0,16Z"
+                fill="#A4Aea2"
+                stroke="#A4Aea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(65.24663677130044,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(65.24663677130044,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L0.35874439461883406,0L0.35874439461883406,16L0,16Z"
+                fill="#A4Aea2"
+                stroke="#A4Aea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(66.32286995515696,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(66.32286995515696,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature4"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.7937219730941703,0L1.7937219730941703,16L0,16Z"
+                fill="black"
+                stroke="black"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(81.39013452914799,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(81.39013452914799,14)"
+                width="1.7937219730941703"
+              />
+            </g>
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.7937219730941703,0L1.7937219730941703,16L0,16Z"
+                fill="black"
+                stroke="black"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(83.54260089686099,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(83.54260089686099,14)"
+                width="1.7937219730941703"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature1"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.0762331838565022,0L1.0762331838565022,16L0,16Z"
+                fill="#339"
+                stroke="#339"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature5"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.0762331838565022,0L1.0762331838565022,16L0,16Z"
+                fill="#63e"
+                stroke="#63e"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature6"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.0762331838565022,0L1.0762331838565022,16L0,16Z"
+                fill="#35d"
+                stroke="#35d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature6_2"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="line feature"
+                d="M0,8 L1.0762331838565022,8"
+                fill="#35d"
+                stroke="#35d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature7"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="bridge feature"
+                d="M0,16L0,8L0.17937219730941703,8L0.17937219730941703,0L0.17937219730941703,8L0.35874439461883406,8L0.35874439461883406,16Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature8"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="bridge feature"
+                d="M0,16L0,0L0.7174887892376681,0L0.7174887892376681,16L0.7174887892376681,2L0,2Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature9"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="diamond feature"
+                d="M0.17937219730941703,0L5.179372197309417,5L0.17937219730941703,10L-4.820627802690583,5Z"
+                fill="#33d"
+                stroke="#33d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature10"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="diamond feature"
+                d="M0.35874439461883406,0L5.358744394618834,5L0.35874439461883406,10L-4.641255605381166,5M0,5L0.7174887892376681,5Z"
+                fill="#33d"
+                stroke="#33d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature11"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="chevron feature"
+                d="M0.17937219730941703,5L5.179372197309417,0L5.179372197309417,5L0.17937219730941703,10L-4.820627802690583,5L-4.820627802690583,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature12"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="chevron feature"
+                d="M0.35874439461883406,5L5.358744394618834,0L5.358744394618834,5L0.35874439461883406,10L-4.641255605381166,5L-4.641255605381166,0L0.35874439461883406,5M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature13"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="catFace feature"
+                d="M-4.820627802690583,0L-4.820627802690583,6L-1.8206278026905829,10L2.179372197309417,10L5.179372197309417,6L5.179372197309417,0L2.179372197309417,4L-1.8206278026905829,4Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature14"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="catFace feature"
+                d="M-4.641255605381166,0L-4.641255605381166,6L-1.641255605381166,10L2.3587443946188342,10L5.358744394618834,6L5.358744394618834,0L2.3587443946188342,4L-1.641255605381166,4M0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature15"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="triangle feature"
+                d="M0.17937219730941703,0L5.179372197309417,10L-4.820627802690583,10Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature16"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="triangle feature"
+                d="M0.35874439461883406,0L5.358744394618834,10L-4.641255605381166,10L0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature17"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="wave feature"
+                d="M-4.820627802690583,5A2.5,5 0 1,1 0.17937219730941703,5A2.5,5 0 1,0 5.179372197309417,5Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature18"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="wave feature"
+                d="M-4.641255605381166,5A2.5,5 0 1,1 0.35874439461883406,5A2.5,5 0 1,0 5.358744394618834,5M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature15"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="hexagon feature"
+                d="M 5.179372197309417,5 2.6793721973094176,9.330127018922193 -2.320627802690582,9.330127018922195 -4.820627802690583,5.000000000000001 -2.320627802690585,0.6698729810778072 2.6793721973094176,0.6698729810778072 Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature16"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="hexagon feature"
+                d="M 5.358744394618834,5 2.8587443946188347,9.330127018922193 -2.141255605381165,9.330127018922195 -4.641255605381166,5.000000000000001 -2.141255605381168,0.6698729810778072 2.8587443946188347,0.6698729810778072  5.358744394618834,5 M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature17"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="pentagon feature"
+                d="M 5.179372197309417,5 1.7244571691841544,9.755282581475768 -3.8657127745653193,7.938926261462367 -3.86571277456532,2.061073738537635 1.7244571691841533,0.2447174185242318 Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature18"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="pentagon feature"
+                d="M 5.358744394618834,5 1.9038293664935713,9.755282581475768 -3.686340577255902,7.938926261462367 -3.686340577255903,2.061073738537635 1.9038293664935702,0.2447174185242318  5.358744394618834,5 M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature19"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="circle feature"
+                d="M0.17937219730941703,0A1.7841241161527712,1.7841241161527712 0 1,1 0.17937219730941703,10A1.7841241161527712,1.7841241161527712 0 1,1 0.17937219730941703,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature20"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="circle feature"
+                d="M0.35874439461883406,0A1.7841241161527712,1.7841241161527712 0 1,1 0.35874439461883406,10A1.7841241161527712,1.7841241161527712 0 1,1 0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature21"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="arrow feature"
+                d="M0.17937219730941703,0L-0.820627802690583,0L-4.820627802690583,4L-0.820627802690583,16L0.17937219730941703,16L4.179372197309417,4Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature22"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="arrow feature"
+                d="M0.35874439461883406,0L-0.641255605381166,0L-4.641255605381166,4L-0.641255605381166,16L0.35874439461883406,16L4.358744394618834,4L0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature19"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="doubleBar feature"
+                d="M0.17937219730941703,0L-4.820627802690583,10L0.17937219730941703,10L5.179372197309417,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature20"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="doubleBar feature"
+                d="M0.35874439461883406,0L-4.641255605381166,10L0.35874439461883406,10L5.358744394618834,0L0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature21"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="helix feature"
+                d=""
+                fill="transparent"
+                stroke="#f06"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature22"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="strand feature"
+                d="M0,4L0,4L0,12L0,12L0,4M0,0L0.35874439461883406,8L0,16Z"
+                fill="#fc0"
+                stroke="#fc0"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+</protvista-track>
+`;
+
+exports[`protvista-track tests it should display the track correctly 1`] = `
+<protvista-track
+  length="223"
+  style="display: block; width: 100%;"
+>
+  <div
+    style="line-height: 0;"
+  >
+    <svg
+      height="44"
+      width="100"
+    >
+      <g
+        class="highlighted"
+      />
+      <g
+        class="sequence-features"
+      >
+        <g
+          class="feature-group"
+          id="g_feature1"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L11.121076233183857,0L11.121076233183857,16L0,16Z"
+                fill="#342ea2"
+                stroke="#342ea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(13.228699551569507,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(13.228699551569507,14)"
+                width="11.121076233183857"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature2"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L39.82062780269058,0L39.82062780269058,16L0,16Z"
+                fill="#A42ea2"
+                stroke="#A42ea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(27.57847533632287,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(27.57847533632287,14)"
+                width="39.82062780269058"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature3"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L0.35874439461883406,0L0.35874439461883406,16L0,16Z"
+                fill="#A4Aea2"
+                stroke="#A4Aea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(65.24663677130044,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(65.24663677130044,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L0.35874439461883406,0L0.35874439461883406,16L0,16Z"
+                fill="#A4Aea2"
+                stroke="#A4Aea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(66.32286995515696,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(66.32286995515696,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature4"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.7937219730941703,0L1.7937219730941703,16L0,16Z"
+                fill="black"
+                stroke="black"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(81.39013452914799,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(81.39013452914799,14)"
+                width="1.7937219730941703"
+              />
+            </g>
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.7937219730941703,0L1.7937219730941703,16L0,16Z"
+                fill="black"
+                stroke="black"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(83.54260089686099,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(83.54260089686099,14)"
+                width="1.7937219730941703"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature1"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.0762331838565022,0L1.0762331838565022,16L0,16Z"
+                fill="#339"
+                stroke="#339"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature5"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.0762331838565022,0L1.0762331838565022,16L0,16Z"
+                fill="#63e"
+                stroke="#63e"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature6"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L1.0762331838565022,0L1.0762331838565022,16L0,16Z"
+                fill="#35d"
+                stroke="#35d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature6_2"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="line feature"
+                d="M0,8 L1.0762331838565022,8"
+                fill="#35d"
+                stroke="#35d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="1.0762331838565022"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature7"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="bridge feature"
+                d="M0,16L0,8L0.17937219730941703,8L0.17937219730941703,0L0.17937219730941703,8L0.35874439461883406,8L0.35874439461883406,16Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature8"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="bridge feature"
+                d="M0,16L0,0L0.7174887892376681,0L0.7174887892376681,16L0.7174887892376681,2L0,2Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature9"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="diamond feature"
+                d="M0.17937219730941703,0L5.179372197309417,5L0.17937219730941703,10L-4.820627802690583,5Z"
+                fill="#33d"
+                stroke="#33d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature10"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="diamond feature"
+                d="M0.35874439461883406,0L5.358744394618834,5L0.35874439461883406,10L-4.641255605381166,5M0,5L0.7174887892376681,5Z"
+                fill="#33d"
+                stroke="#33d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature11"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="chevron feature"
+                d="M0.17937219730941703,5L5.179372197309417,0L5.179372197309417,5L0.17937219730941703,10L-4.820627802690583,5L-4.820627802690583,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature12"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="chevron feature"
+                d="M0.35874439461883406,5L5.358744394618834,0L5.358744394618834,5L0.35874439461883406,10L-4.641255605381166,5L-4.641255605381166,0L0.35874439461883406,5M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature13"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="catFace feature"
+                d="M-4.820627802690583,0L-4.820627802690583,6L-1.8206278026905829,10L2.179372197309417,10L5.179372197309417,6L5.179372197309417,0L2.179372197309417,4L-1.8206278026905829,4Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature14"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="catFace feature"
+                d="M-4.641255605381166,0L-4.641255605381166,6L-1.641255605381166,10L2.3587443946188342,10L5.358744394618834,6L5.358744394618834,0L2.3587443946188342,4L-1.641255605381166,4M0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature15"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="triangle feature"
+                d="M0.17937219730941703,0L5.179372197309417,10L-4.820627802690583,10Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature16"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="triangle feature"
+                d="M0.35874439461883406,0L5.358744394618834,10L-4.641255605381166,10L0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature17"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="wave feature"
+                d="M-4.820627802690583,5A2.5,5 0 1,1 0.17937219730941703,5A2.5,5 0 1,0 5.179372197309417,5Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature18"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="wave feature"
+                d="M-4.641255605381166,5A2.5,5 0 1,1 0.35874439461883406,5A2.5,5 0 1,0 5.358744394618834,5M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature15"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="hexagon feature"
+                d="M 5.179372197309417,5 2.6793721973094176,9.330127018922193 -2.320627802690582,9.330127018922195 -4.820627802690583,5.000000000000001 -2.320627802690585,0.6698729810778072 2.6793721973094176,0.6698729810778072 Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature16"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="hexagon feature"
+                d="M 5.358744394618834,5 2.8587443946188347,9.330127018922193 -2.141255605381165,9.330127018922195 -4.641255605381166,5.000000000000001 -2.141255605381168,0.6698729810778072 2.8587443946188347,0.6698729810778072  5.358744394618834,5 M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature17"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="pentagon feature"
+                d="M 5.179372197309417,5 1.7244571691841544,9.755282581475768 -3.8657127745653193,7.938926261462367 -3.86571277456532,2.061073738537635 1.7244571691841533,0.2447174185242318 Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature18"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="pentagon feature"
+                d="M 5.358744394618834,5 1.9038293664935713,9.755282581475768 -3.686340577255902,7.938926261462367 -3.686340577255903,2.061073738537635 1.9038293664935702,0.2447174185242318  5.358744394618834,5 M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature19"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="circle feature"
+                d="M0.17937219730941703,0A1.7841241161527712,1.7841241161527712 0 1,1 0.17937219730941703,10A1.7841241161527712,1.7841241161527712 0 1,1 0.17937219730941703,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature20"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="circle feature"
+                d="M0.35874439461883406,0A1.7841241161527712,1.7841241161527712 0 1,1 0.35874439461883406,10A1.7841241161527712,1.7841241161527712 0 1,1 0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature21"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="arrow feature"
+                d="M0.17937219730941703,0L-0.820627802690583,0L-4.820627802690583,4L-0.820627802690583,16L0.17937219730941703,16L4.179372197309417,4Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature22"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="arrow feature"
+                d="M0.35874439461883406,0L-0.641255605381166,0L-4.641255605381166,4L-0.641255605381166,16L0.35874439461883406,16L4.358744394618834,4L0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature19"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="doubleBar feature"
+                d="M0.17937219730941703,0L-4.820627802690583,10L0.17937219730941703,10L5.179372197309417,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature20"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="doubleBar feature"
+                d="M0.35874439461883406,0L-4.641255605381166,10L0.35874439461883406,10L5.358744394618834,0L0.35874439461883406,0M0,5L0.7174887892376681,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature21"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="helix feature"
+                d=""
+                fill="transparent"
+                stroke="#f06"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="0.7174887892376681"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature22"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="strand feature"
+                d="M0,4L0,4L0,12L0,12L0,4M0,0L0.35874439461883406,8L0,16Z"
+                fill="#fc0"
+                stroke="#fc0"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10.358744394618833,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10.358744394618833,14)"
+                width="0.35874439461883406"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+</protvista-track>
+`;
+
+exports[`protvista-track tests it should zoom in 1`] = `
+<protvista-track
+  displayend="4"
+  displaystart="2"
+  length="223"
+  style="display: block; width: 100%;"
+>
+  <div
+    style="line-height: 0;"
+  >
+    <svg
+      height="44"
+      width="100"
+    >
+      <g
+        class="highlighted"
+      >
+        <rect
+          fill="rgba(255, 235, 59, 0.8)"
+          height="44"
+          style="opacity: 0.5; pointer-events: none;"
+          width="0"
+          x="-16.666666666666664"
+        />
+      </g>
+      <g
+        class="sequence-features"
+      >
+        <g
+          class="feature-group"
+          id="g_feature1"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L826.6666666666666,0L826.6666666666666,16L0,16Z"
+                fill="#342ea2"
+                stroke="#342ea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(223.33333333333331,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(223.33333333333331,14)"
+                width="826.6666666666666"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature2"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L2959.9999999999995,0L2959.9999999999995,16L0,16Z"
+                fill="#A42ea2"
+                stroke="#A42ea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(1290,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(1290,14)"
+                width="2959.9999999999995"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature3"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L26.666666666666664,0L26.666666666666664,16L0,16Z"
+                fill="#A4Aea2"
+                stroke="#A4Aea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(4090,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(4090,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L26.666666666666664,0L26.666666666666664,16L0,16Z"
+                fill="#A4Aea2"
+                stroke="#A4Aea2"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(4170,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(4170,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature4"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L133.33333333333331,0L133.33333333333331,16L0,16Z"
+                fill="black"
+                stroke="black"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(5290,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(5290,14)"
+                width="133.33333333333331"
+              />
+            </g>
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L133.33333333333331,0L133.33333333333331,16L0,16Z"
+                fill="black"
+                stroke="black"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(5450,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(5450,14)"
+                width="133.33333333333331"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature1"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L80,0L80,16L0,16Z"
+                fill="#339"
+                stroke="#339"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="80"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature5"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L80,0L80,16L0,16Z"
+                fill="#63e"
+                stroke="#63e"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="80"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature6"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="rectangle feature"
+                d="M0,0L80,0L80,16L0,16Z"
+                fill="#35d"
+                stroke="#35d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="80"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature6_2"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="line feature"
+                d="M0,8 L80,8"
+                fill="#35d"
+                stroke="#35d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="80"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature7"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="bridge feature"
+                d="M0,16L0,8L13.333333333333332,8L13.333333333333332,0L13.333333333333332,8L26.666666666666664,8L26.666666666666664,16Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature8"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="bridge feature"
+                d="M0,16L0,0L53.33333333333333,0L53.33333333333333,16L53.33333333333333,2L0,2Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature9"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="diamond feature"
+                d="M13.333333333333332,0L18.333333333333332,5L13.333333333333332,10L8.333333333333332,5Z"
+                fill="#33d"
+                stroke="#33d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature10"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="diamond feature"
+                d="M26.666666666666664,0L31.666666666666664,5L26.666666666666664,10L21.666666666666664,5M0,5L53.33333333333333,5Z"
+                fill="#33d"
+                stroke="#33d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature11"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="chevron feature"
+                d="M13.333333333333332,5L18.333333333333332,0L18.333333333333332,5L13.333333333333332,10L8.333333333333332,5L8.333333333333332,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature12"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="chevron feature"
+                d="M26.666666666666664,5L31.666666666666664,0L31.666666666666664,5L26.666666666666664,10L21.666666666666664,5L21.666666666666664,0L26.666666666666664,5M0,5L53.33333333333333,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature13"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="catFace feature"
+                d="M8.333333333333332,0L8.333333333333332,6L11.333333333333332,10L15.333333333333332,10L18.333333333333332,6L18.333333333333332,0L15.333333333333332,4L11.333333333333332,4Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature14"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="catFace feature"
+                d="M21.666666666666664,0L21.666666666666664,6L24.666666666666664,10L28.666666666666664,10L31.666666666666664,6L31.666666666666664,0L28.666666666666664,4L24.666666666666664,4M26.666666666666664,0M0,5L53.33333333333333,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature15"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="triangle feature"
+                d="M13.333333333333332,0L18.333333333333332,10L8.333333333333332,10Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature16"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="triangle feature"
+                d="M26.666666666666664,0L31.666666666666664,10L21.666666666666664,10L26.666666666666664,0M0,5L53.33333333333333,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature17"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="wave feature"
+                d="M8.333333333333332,5A2.5,5 0 1,1 13.333333333333332,5A2.5,5 0 1,0 18.333333333333332,5Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature18"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="wave feature"
+                d="M21.666666666666664,5A2.5,5 0 1,1 26.666666666666664,5A2.5,5 0 1,0 31.666666666666664,5M0,5L53.33333333333333,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature15"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="hexagon feature"
+                d="M 18.333333333333332,5 15.833333333333332,9.330127018922193 10.833333333333332,9.330127018922195 8.333333333333332,5.000000000000001 10.83333333333333,0.6698729810778072 15.833333333333332,0.6698729810778072 Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature16"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="hexagon feature"
+                d="M 31.666666666666664,5 29.166666666666664,9.330127018922193 24.166666666666664,9.330127018922195 21.666666666666664,5.000000000000001 24.16666666666666,0.6698729810778072 29.166666666666664,0.6698729810778072  31.666666666666664,5 M0,5L53.33333333333333,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature17"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="pentagon feature"
+                d="M 18.333333333333332,5 14.878418305208069,9.755282581475768 9.288248361458596,7.938926261462367 9.288248361458596,2.061073738537635 14.878418305208069,0.2447174185242318 Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature18"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="pentagon feature"
+                d="M 31.666666666666664,5 28.2117516385414,9.755282581475768 22.621581694791928,7.938926261462367 22.621581694791928,2.061073738537635 28.2117516385414,0.2447174185242318  31.666666666666664,5 M0,5L53.33333333333333,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature19"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="circle feature"
+                d="M13.333333333333332,0A1.7841241161527712,1.7841241161527712 0 1,1 13.333333333333332,10A1.7841241161527712,1.7841241161527712 0 1,1 13.333333333333332,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature20"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="circle feature"
+                d="M26.666666666666664,0A1.7841241161527712,1.7841241161527712 0 1,1 26.666666666666664,10A1.7841241161527712,1.7841241161527712 0 1,1 26.666666666666664,0M0,5L53.33333333333333,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature21"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="arrow feature"
+                d="M13.333333333333332,0L12.333333333333332,0L8.333333333333332,4L12.333333333333332,16L13.333333333333332,16L17.333333333333332,4Z"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature22"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="arrow feature"
+                d="M26.666666666666664,0L25.666666666666664,0L21.666666666666664,4L25.666666666666664,16L26.666666666666664,16L30.666666666666664,4L26.666666666666664,0M0,5L53.33333333333333,5ZZ"
+                fill="#d3d"
+                stroke="#d3d"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature19"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="doubleBar feature"
+                d="M13.333333333333332,0L8.333333333333332,10L13.333333333333332,10L18.333333333333332,0Z"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature20"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="doubleBar feature"
+                d="M26.666666666666664,0L21.666666666666664,10L26.666666666666664,10L31.666666666666664,0L26.666666666666664,0M0,5L53.33333333333333,5ZZ"
+                fill="#3a3"
+                stroke="#3a3"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature21"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="helix feature"
+                d="M0,16 C5,7.5 5,2.5 2.5, 0 C0,2.5 2.5,7.5 5,16M5,16 C10,7.5 10,2.5 7.5, 0 C5,2.5 7.5,7.5 10,16M10,16 C15,7.5 15,2.5 12.5, 0 C10,2.5 12.5,7.5 15,16M15,16 C20,7.5 20,2.5 17.5, 0 C15,2.5 17.5,7.5 20,16M20,16 C25,7.5 25,2.5 22.5, 0 C20,2.5 22.5,7.5 25,16M25,16 C30,7.5 30,2.5 27.5, 0 C25,2.5 27.5,7.5 30,16M30,16 C35,7.5 35,2.5 32.5, 0 C30,2.5 32.5,7.5 35,16M35,16 C40,7.5 40,2.5 37.5, 0 C35,2.5 37.5,7.5 40,16M40,16 C45,7.5 45,2.5 42.5, 0 C40,2.5 42.5,7.5 45,16M45,16 C50,7.5 50,2.5 47.5, 0 C45,2.5 47.5,7.5 50,16M50,16 C55,7.5 55,2.5 52.5, 0 C50,2.5 52.5,7.5 55,16"
+                fill="transparent"
+                stroke="#f06"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(-16.666666666666664,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(-16.666666666666664,14)"
+                width="53.33333333333333"
+              />
+            </g>
+          </g>
+        </g>
+        <g
+          class="feature-group"
+          id="g_feature22"
+        >
+          <g
+            class="location-group"
+          >
+            <g
+              class="fragment-group"
+            >
+              <path
+                class="strand feature"
+                d="M0,4L21.666666666666664,4L21.666666666666664,12L0,12L0,4M21.666666666666664,0L26.666666666666664,8L21.666666666666664,16Z"
+                fill="#fc0"
+                stroke="#fc0"
+                style="fill-opacity: 0.9; stroke-opacity: 0.9;"
+                transform="translate(10,14)"
+              />
+              <rect
+                class="outer-rectangle feature"
+                fill="transparent"
+                height="16"
+                stroke="transparent"
+                transform="translate(10,14)"
+                width="26.666666666666664"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+</protvista-track>
+`;

--- a/packages/protvista-track/tests/mockData/data.json
+++ b/packages/protvista-track/tests/mockData/data.json
@@ -1,0 +1,219 @@
+[
+  {
+    "accession": "feature1",
+    "start": 10,
+    "end": 40,
+    "color": "#342ea2"
+  },
+  {
+    "accession": "feature2",
+    "locations": [{ "fragments": [{ "start": 50, "end": 160 }] }],
+    "color": "#A42ea2"
+  },
+  {
+    "accession": "feature3",
+    "locations": [
+      {
+        "fragments": [{ "start": 155, "end": 155 }]
+      },
+      { "fragments": [{ "start": 158, "end": 158 }] }
+    ],
+    "color": "#A4Aea2"
+  },
+  {
+    "accession": "feature4",
+    "locations": [
+      {
+        "fragments": [
+          { "start": 200, "end": 204 },
+          { "start": 206, "end": 210 }
+        ]
+      }
+    ]
+  },
+  { "accession": "feature1", "start": 1, "end": 3, "color": "#339" },
+  { "accession": "feature5", "start": 1, "end": 3, "color": "#63e" },
+  {
+    "accession": "feature6",
+    "start": 1,
+    "end": 3,
+    "color": "#35d",
+    "shape": "rectangle"
+  },
+  {
+    "accession": "feature6_2",
+    "start": 1,
+    "end": 3,
+    "color": "#35d",
+    "shape": "line"
+  },
+  {
+    "accession": "feature7",
+    "start": 2,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "bridge"
+  },
+  {
+    "accession": "feature8",
+    "start": 1,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "bridge"
+  },
+  {
+    "accession": "feature9",
+    "start": 2,
+    "end": 2,
+    "color": "#33d",
+    "shape": "diamond"
+  },
+  {
+    "accession": "feature10",
+    "start": 2,
+    "end": 3,
+    "color": "#33d",
+    "shape": "diamond"
+  },
+  {
+    "accession": "feature11",
+    "start": 2,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "chevron"
+  },
+  {
+    "accession": "feature12",
+    "start": 1,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "chevron"
+  },
+  {
+    "accession": "feature13",
+    "start": 2,
+    "end": 2,
+    "color": "#d3d",
+    "shape": "catFace"
+  },
+  {
+    "accession": "feature14",
+    "start": 2,
+    "end": 3,
+    "color": "#d3d",
+    "shape": "catFace"
+  },
+  {
+    "accession": "feature15",
+    "start": 2,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "triangle"
+  },
+  {
+    "accession": "feature16",
+    "start": 1,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "triangle"
+  },
+  {
+    "accession": "feature17",
+    "start": 2,
+    "end": 2,
+    "color": "#d3d",
+    "shape": "wave"
+  },
+  {
+    "accession": "feature18",
+    "start": 2,
+    "end": 3,
+    "color": "#d3d",
+    "shape": "wave"
+  },
+  {
+    "accession": "feature15",
+    "start": 2,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "hexagon"
+  },
+  {
+    "accession": "feature16",
+    "start": 1,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "hexagon"
+  },
+  {
+    "accession": "feature17",
+    "start": 2,
+    "end": 2,
+    "color": "#d3d",
+    "shape": "pentagon"
+  },
+  {
+    "accession": "feature18",
+    "start": 2,
+    "end": 3,
+    "color": "#d3d",
+    "shape": "pentagon"
+  },
+  {
+    "accession": "feature19",
+    "start": 2,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "circle"
+  },
+  {
+    "accession": "feature20",
+    "start": 1,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "circle"
+  },
+  {
+    "accession": "feature21",
+    "start": 2,
+    "end": 2,
+    "color": "#d3d",
+    "shape": "arrow"
+  },
+  {
+    "accession": "feature22",
+    "start": 2,
+    "end": 3,
+    "color": "#d3d",
+    "shape": "arrow"
+  },
+  {
+    "accession": "feature19",
+    "start": 2,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "doubleBar"
+  },
+  {
+    "accession": "feature20",
+    "start": 1,
+    "end": 2,
+    "color": "#3a3",
+    "shape": "doubleBar"
+  },
+  {
+    "accession": "feature21",
+    "start": 1,
+    "end": 2,
+    "color": "#f06",
+    "shape": "helix",
+    "fill": "transparent"
+  },
+  {
+    "accession": "feature22",
+    "start": 2,
+    "end": 2,
+    "color": "#fc0",
+    "shape": "strand"
+  }
+]

--- a/packages/protvista-track/tests/protvista-track.test.js
+++ b/packages/protvista-track/tests/protvista-track.test.js
@@ -1,0 +1,49 @@
+import ProtvistaTrack from "../src/protvista-track";
+import data from "./mockData/data.json";
+
+let rendered;
+
+describe("protvista-track tests", () => {
+  beforeAll(() => {
+    // TODO remove when the definition is part of the import
+    window.customElements.define("protvista-track", ProtvistaTrack);
+  });
+  beforeEach(() => {
+    document.documentElement.innerHTML = `<protvista-track length="223"></protvista-track>`;
+    rendered = document.querySelector("protvista-track");
+    rendered.data = data;
+  });
+
+  afterEach(() => {
+    document.querySelector("protvista-track").remove();
+  });
+
+  test("it should display the track correctly", async () => {
+    expect(rendered).toMatchSnapshot();
+  });
+
+  test("it should zoom in", async (done) => {
+    rendered.setAttribute("displaystart", "2");
+    rendered.setAttribute("displayend", "4");
+    window.requestAnimationFrame(() => {
+      expect(rendered).toMatchSnapshot();
+      done();
+    });
+  });
+
+  test("it should change the layout", async (done) => {
+    rendered.setAttribute("layout", "non-overlapping");
+    window.requestAnimationFrame(() => {
+      expect(rendered).toMatchSnapshot();
+      done();
+    });
+  });
+
+  test("it should display the sequence correctly after highlight", (done) => {
+    rendered.setAttribute("highlight", "10:30");
+    window.requestAnimationFrame(() => {
+      expect(rendered).toMatchSnapshot();
+      done();
+    });
+  });
+});

--- a/packages/protvista-utils/src/TrackHighlighter.js
+++ b/packages/protvista-utils/src/TrackHighlighter.js
@@ -18,25 +18,6 @@ export default class TrackHighlighter {
 
   setAttributesInElement() {
     this.region.decode(this.element.getAttribute("highlight"));
-    if (this.region.segments.length === 0) {
-      this.element._highlightstart = Number(
-        this.element.getAttribute("highlightstart")
-      );
-      this.element._highlightend = Number(
-        this.element.getAttribute("highlightend")
-      );
-      if (
-        this.element._highlightstart !== null &&
-        this.element._highlightend !== null &&
-        typeof this.element._highlightstart === "number" &&
-        typeof this.element._highlightend === "number"
-      ) {
-        this.element._highlight = `${this.element._highlightstart}:${this.element._highlightend}`;
-        this.region.decode(
-          combineRegions(this.fixedHighlight, this.element._highlight)
-        );
-      }
-    }
   }
 
   setFloatAttribute(name, strValue) {
@@ -45,30 +26,13 @@ export default class TrackHighlighter {
   }
 
   changedCallBack(name, newValue) {
-    switch (name) {
-      case "highlightstart":
-      case "highlightend":
-        this.setFloatAttribute(name, newValue);
-        this.element._highlight =
-          Number.isNaN(this.element._highlightstart) ||
-          Number.isNaN(this.element._highlightend) ||
-          this.element._highlightstart === undefined ||
-          this.element._highlightend === undefined ||
-          this.element._highlightstart === null ||
-          this.element._highlightend === null
-            ? ""
-            : `${Math.max(
-                this.region.min,
-                this.element._highlightstart
-              )}:${Math.min(this.region.max, this.element._highlightend)}`;
-        break;
-      default:
-        this.element._highlight = newValue;
+    if (name === "highlight") {
+      this.element._highlight = newValue;
+      this.region.decode(
+        combineRegions(this.fixedHighlight, this.element._highlight)
+      );
+      this.element.refresh();
     }
-    this.region.decode(
-      combineRegions(this.fixedHighlight, this.element._highlight)
-    );
-    this.element.refresh();
   }
 
   setFixedHighlight(region) {
@@ -93,10 +57,10 @@ export default class TrackHighlighter {
       .style("pointer-events", "none")
       .merge(highlighs)
       .attr("height", this.element._height)
-      .attr("x", d => this.element.getXFromSeqPosition(d.start))
+      .attr("x", (d) => this.element.getXFromSeqPosition(d.start))
       .attr(
         "width",
-        d => this.element.getSingleBaseWidth() * (d.end - d.start + 1)
+        (d) => this.element.getSingleBaseWidth() * (d.end - d.start + 1)
       );
     highlighs.exit().remove();
   }

--- a/packages/protvista-zoomable/README.md
+++ b/packages/protvista-zoomable/README.md
@@ -147,7 +147,7 @@ Disconnects the resize observer.
 
 #### `observedAttributes()`
 
-The observed attributes are: `["displaystart", "displayend", "length"]`.
+The observed attributes are: `["displaystart", "displayend", "length", "highlight]`.
 
 _Note_: If you are overwriting this method in your component, make sure to include those defined here,
 otherwise the zooming functionality might be compromised. For example:
@@ -155,8 +155,7 @@ otherwise the zooming functionality might be compromised. For example:
 ```javascript
  static get observedAttributes() {
    return ProtvistaZoomable.observedAttributes.concat(
-     "highlightstart",
-     "highlightend",
+     "my_observed_attr",
    );
  }
 ```
@@ -179,7 +178,7 @@ Returns the default values of the margin. you should overwrite this to define yo
   top: 10,
   right: 10,
   bottom: 10,
-  left: 10
+  left: 10,
 }
 ```
 
@@ -207,8 +206,8 @@ The detail of the event includes the new coordinates. For example:
 {
   detail: {
     displaystart: 3,
-    displayend: 5
-  }
+    displayend: 5,
+  },
 }
 ```
 


### PR DESCRIPTION
- Had basic tests for `protvista-track`
- Remove `highlightstart` and `highlightend` which were replaced by `highlight` a few years (?) ago