### PR TITLE
Use slots and css variables

### DIFF
--- a/app/src/components/ProtvistaManager.jsx
+++ b/app/src/components/ProtvistaManager.jsx
@@ -113,6 +113,7 @@ class ProtvistaManagerWrapper extends Component {
             }}
           >
             <span slot="zoom-in">+</span>
+            <span slot="zoom-in-seq">Zoom to Sequence</span>
           </protvista-zoom-tool>
           <protvista-navigation length="770" />
           <div id="just-tracks">

--- a/app/src/components/ProtvistaManager.jsx
+++ b/app/src/components/ProtvistaManager.jsx
@@ -109,6 +109,7 @@ class ProtvistaManagerWrapper extends Component {
               "--button-background": "#00639a",
               "--button-text-color": "#FFFFFF",
               "--button-background-focus": "#00a6d5",
+              "--button-border-radius": "4px",
             }}
           >
             <span slot="zoom-in">+</span>

--- a/app/src/components/ProtvistaManager.jsx
+++ b/app/src/components/ProtvistaManager.jsx
@@ -102,7 +102,17 @@ class ProtvistaManagerWrapper extends Component {
           displayend="100"
           id="example"
         >
-          <protvista-zoom-tool length="770" style={{ float: "right" }} />
+          <protvista-zoom-tool
+            length="770"
+            style={{
+              float: "right",
+              "--button-background": "#00639a",
+              "--button-text-color": "#FFFFFF",
+              "--button-background-focus": "#00a6d5",
+            }}
+          >
+            <span slot="zoom-in">+</span>
+          </protvista-zoom-tool>
           <protvista-navigation length="770" />
           <div id="just-tracks">
             <protvista-sequence

--- a/packages/protvista-zoom-tool/src/ProtvistaZoomTool.js
+++ b/packages/protvista-zoom-tool/src/ProtvistaZoomTool.js
@@ -17,7 +17,7 @@ class ProtvistaZoomTool extends HTMLElement {
       parseFloat(this.getAttribute("displayend")) || this._length;
     this._scaleFactor =
       parseFloat(this.getAttribute("scalefactor")) || this._length / 5;
-
+    this._zoomToSeq = this.querySelector('[slot="zoom-in-seq"]') !== null;
     this.renderContent();
   }
 
@@ -99,9 +99,14 @@ class ProtvistaZoomTool extends HTMLElement {
       <button @click=${() => this.zoom("zoom-in")} title="Zoom In">
         <slot name="zoom-in">Zoom in</slot>
       </button>
-      <button @click=${() => this.zoom("zoom-in-seq")} title="Zoom to sequence">
-        <slot name="zoom-in-seq">Zoom in to sequence</slot>
-      </button>
+      ${this._zoomToSeq
+        ? html`<button
+            @click=${() => this.zoom("zoom-in-seq")}
+            title="Zoom to sequence"
+          >
+            <slot name="zoom-in-seq"></slot>
+          </button>`
+        : ""}
     `;
     render(content, this.shadowRoot);
   }

--- a/packages/protvista-zoom-tool/src/ProtvistaZoomTool.js
+++ b/packages/protvista-zoom-tool/src/ProtvistaZoomTool.js
@@ -15,7 +15,8 @@ class ProtvistaZoomTool extends HTMLElement {
     this._displaystart = parseFloat(this.getAttribute("displaystart")) || 1;
     this._displayend =
       parseFloat(this.getAttribute("displayend")) || this._length;
-    this._scaleFactor = parseFloat(this.getAttribute("scalefactor")) || 10;
+    this._scaleFactor =
+      parseFloat(this.getAttribute("scalefactor")) || this._length / 5;
 
     this.renderContent();
   }
@@ -31,15 +32,24 @@ class ProtvistaZoomTool extends HTMLElement {
   }
 
   zoom(operation) {
-    let k;
-    if (operation === "zoom-in") k = this._scaleFactor;
-    else k = -this._scaleFactor;
-    const newStart =
-      this._displaystart === 1
-        ? this._displaystart - 1 + k
-        : this._displaystart + k;
+    let k = 0;
+    if (operation === "zoom-in") {
+      k = this._scaleFactor;
+    } else if (operation === "zoom-out") {
+      k = -this._scaleFactor;
+    } else if (operation === "zoom-in-seq") {
+      k =
+        this._displayend -
+        this._displaystart -
+        (this._displaystart === 1 ? 29 : 30);
+    }
     const newEnd = this._displayend - k;
-    if (newStart < newEnd) {
+    let newStart = this._displaystart;
+    // if we've reached the end when zooming out, remove from start
+    if (newEnd > this._length) {
+      newStart -= newEnd - this._length;
+    }
+    if (this._displaystart < newEnd) {
       this.dispatchEvent(
         new CustomEvent("change", {
           detail: {
@@ -64,8 +74,9 @@ class ProtvistaZoomTool extends HTMLElement {
           text-decoration: none;
           background: var(--button-background, #d3d3d3);
           color: var(--button-text-color);
-          font-family: var(--font-family, sans-serif);
-          font-size: var(--font-size, 1rem);
+          font-family: var(--button-font-family, sans-serif);
+          font-size: var(--button-font-size, 1rem);
+          border-radius: var(--button-border-radius, 0);
           cursor: pointer;
           text-align: center;
           transition: var(
@@ -87,6 +98,9 @@ class ProtvistaZoomTool extends HTMLElement {
       </button>
       <button @click=${() => this.zoom("zoom-in")} title="Zoom In">
         <slot name="zoom-in">Zoom in</slot>
+      </button>
+      <button @click=${() => this.zoom("zoom-in-seq")} title="Zoom to sequence">
+        <slot name="zoom-in-seq">Zoom in to sequence</slot>
       </button>
     `;
     render(content, this.shadowRoot);

--- a/packages/protvista-zoom-tool/src/ProtvistaZoomTool.js
+++ b/packages/protvista-zoom-tool/src/ProtvistaZoomTool.js
@@ -1,6 +1,11 @@
 import { html, render } from "lit-html";
 
 class ProtvistaZoomTool extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+  }
+
   connectedCallback() {
     if (this.closest("protvista-manager")) {
       this.manager = this.closest("protvista-manager");
@@ -39,62 +44,52 @@ class ProtvistaZoomTool extends HTMLElement {
         new CustomEvent("change", {
           detail: {
             displaystart: Math.max(1, newStart),
-            displayend: Math.min(newEnd, this._length)
+            displayend: Math.min(newEnd, this._length),
           },
           bubbles: true,
-          cancelable: true
+          cancelable: true,
         })
       );
     }
   }
 
   renderContent() {
-    let zoomInButton = html`
-      <button
-        style="cursor: pointer; border-radius: 4px;"
-        @click=${() => this.zoom("zoom-in")}
-        id="zoom-in"
-        title="Zoom In"
-      >
-        +
-      </button>
-    `;
-    let zoomOutButton = html`
-      <button
-        style="cursor: pointer; border-radius: 4px;"
-        @click=${() => this.zoom("zoom-out")}
-        id="zoom-out"
-        title="Zoom Out"
-      >
-        -
-      </button>
-    `;
-
-    /* The buttons can be customised but they should contain the respective ids -
-     * 'zoom-in' or 'zoom-out'. Otherwise the default buttons are shown
-     * */
-    if (this.hasChildNodes()) {
-      const { children } = this;
-      Array.from(children).forEach(child => {
-        if (child.tagName === "BUTTON") {
-          child.addEventListener("click", () => this.zoom(child.id));
-          if (child.id === "zoom-in")
-            zoomInButton = html`
-              ${child}
-            `;
-          else if (child.id === "zoom-out")
-            zoomOutButton = html`
-              ${child}
-            `;
-        }
-      });
-    }
     const content = html`
-      <div class="zoom-button-div">
-        ${zoomInButton} ${zoomOutButton}
-      </div>
+      <style>
+        button {
+          display: inline-block;
+          border: none;
+          padding: var(--button-padding-v, 0.5rem) var(--button-padding-h, 1rem);
+          margin: var(--button-margin-v, 0) var(--button-margin-h, 0);
+          text-decoration: none;
+          background: var(--button-background, #d3d3d3);
+          color: var(--button-text-color);
+          font-family: var(--font-family, sans-serif);
+          font-size: var(--font-size, 1rem);
+          cursor: pointer;
+          text-align: center;
+          transition: var(
+            --button-transition,
+            background 250ms ease-in-out,
+            transform 150ms ease
+          );
+          -webkit-appearance: none;
+          -moz-appearance: none;
+        }
+
+        button:hover,
+        button:focus {
+          background: var(--button-background-focus);
+        }
+      </style>
+      <button @click=${() => this.zoom("zoom-out")} title="Zoom Out">
+        <slot name="zoom-out">Zoom out</slot>
+      </button>
+      <button @click=${() => this.zoom("zoom-in")} title="Zoom In">
+        <slot name="zoom-in">Zoom in</slot>
+      </button>
     `;
-    render(content, this);
+    render(content, this.shadowRoot);
   }
 }
 

--- a/packages/protvista-zoom-tool/src/ProtvistaZoomTool.js
+++ b/packages/protvista-zoom-tool/src/ProtvistaZoomTool.js
@@ -38,10 +38,7 @@ class ProtvistaZoomTool extends HTMLElement {
     } else if (operation === "zoom-out") {
       k = -this._scaleFactor;
     } else if (operation === "zoom-in-seq") {
-      k =
-        this._displayend -
-        this._displaystart -
-        (this._displaystart === 1 ? 29 : 30);
+      k = this._displayend - this._displaystart - 29;
     }
     const newEnd = this._displayend - k;
     let newStart = this._displaystart;


### PR DESCRIPTION
### Reference to issue
#128 

### Description of changes
- For the content of `<button/>`, change to using slots
- css to reset the button styling and apply default styles, and expose some properties through css variables
- Add an option (through a slot) to provide an extra button to zoom in right to the sequence level (30 amino acids)
- Refactor the zooming logic to only move the `end` unless it's reached the full length

These changes will have implications with InterPro's use of the component @Swaathik @gustavo-salazar 

### Tests / Styleguide
 - [x] Tests pass
 - [x] Styleguide
