### PR TITLE
Add support for Ensembl COVID-19 links

### DIFF
--- a/packages/protvista-variation-adapter/src/tooltipGenerators.ts
+++ b/packages/protvista-variation-adapter/src/tooltipGenerators.ts
@@ -46,6 +46,20 @@ export const getPopulationFrequencies = (
     )
     .join("")}`;
 
+export const getEnsemblCovidLinks = (variant: Variant) => {
+  const shouldGenerateLink = variant.locations.some(
+    (location) => location.source === "EnsemblViruses"
+  );
+  if (shouldGenerateLink) {
+    const { id } = variant.xrefs.find((xref) => xref.name === "ENA");
+    return (
+      `<h5>Ensembl COVID-19</h5>` +
+      `<p><a href="https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?v=${id}" target="_blank" rel="noopener noreferrer">${id}</a></p>`
+    );
+  }
+  return "";
+};
+
 export const getPredictions = (predictions: Prediction[]) => {
   const groupedPredictions = groupBy(predictions, "predAlgorithmNameType");
   const counts = Object.keys(groupedPredictions).map((key) => {
@@ -115,7 +129,7 @@ export const formatTooltip = (variant: Variant) =>
                 ${
                   variant.predictions ? getPredictions(variant.predictions) : ""
                 }
-
+                ${getEnsemblCovidLinks(variant)}
                 
         `;
 

--- a/packages/protvista-variation-adapter/src/tooltipGenerators.ts
+++ b/packages/protvista-variation-adapter/src/tooltipGenerators.ts
@@ -51,11 +51,13 @@ export const getEnsemblCovidLinks = (variant: Variant) => {
     (location) => location.source === "EnsemblViruses"
   );
   if (shouldGenerateLink) {
-    const { id } = variant.xrefs.find((xref) => xref.name === "ENA");
-    return (
-      `<h5>Ensembl COVID-19</h5>` +
-      `<p><a href="https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?v=${id}" target="_blank" rel="noopener noreferrer">${id}</a></p>`
-    );
+    const xref = variant.xrefs.find((xref) => xref.name === "ENA");
+    return xref.id
+      ? `<h5>Ensembl COVID-19</h5>
+          <p>
+          <a href="https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?v=${xref.id}" target="_blank" rel="noopener noreferrer">${xref.id}</a>
+        </p>`
+      : "";
   }
   return "";
 };

--- a/packages/protvista-variation-adapter/src/variants.ts
+++ b/packages/protvista-variation-adapter/src/variants.ts
@@ -116,6 +116,7 @@ export enum Source {
   SGD = "SGD",
   JEFFARES_SNPS = "Jeffares_SNPs",
   JEFFARES_INDELS = "Jeffares_Indels",
+  ENSEMBL_VIRUSES = "EnsemblViruses",
 }
 
 export type Evidence = {

--- a/packages/protvista-variation-adapter/test/ProtvistaVariationAdapter.spec.js
+++ b/packages/protvista-variation-adapter/test/ProtvistaVariationAdapter.spec.js
@@ -5,6 +5,7 @@ import {
   getDescriptions,
   getPopulationFrequencies,
   getPredictions,
+  getEnsemblCovidLinks,
 } from "../src/tooltipGenerators";
 
 describe("ProtvistaVariationAdapter", () => {
@@ -36,6 +37,14 @@ describe("ProtvistaVariationAdapter", () => {
 
   it("should transform the data adequately", () => {
     const data = transformData(variants);
+    expect(data).toMatchSnapshot();
+  });
+
+  it("should generate the Ensembl covid link only if present", () => {
+    const { features } = variants;
+    let data = getEnsemblCovidLinks(features[0]);
+    expect(data).toMatchSnapshot();
+    data = getEnsemblCovidLinks(features[1]);
     expect(data).toMatchSnapshot();
   });
 });

--- a/packages/protvista-variation-adapter/test/__snapshots__/ProtvistaVariationAdapter.spec.js.snap
+++ b/packages/protvista-variation-adapter/test/__snapshots__/ProtvistaVariationAdapter.spec.js.snap
@@ -22,7 +22,12 @@ exports[`ProtvistaVariationAdapter should format predictions 1`] = `"<h6>PolyPhe
 
 exports[`ProtvistaVariationAdapter should generate the Ensembl covid link only if present 1`] = `""`;
 
-exports[`ProtvistaVariationAdapter should generate the Ensembl covid link only if present 2`] = `"<h5>Ensembl COVID-19</h5><p><a href=\\"https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?v=MN908947.3:21568:T:A\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">MN908947.3:21568:T:A</a></p>"`;
+exports[`ProtvistaVariationAdapter should generate the Ensembl covid link only if present 2`] = `
+"<h5>Ensembl COVID-19</h5>
+          <p>
+          <a href=\\"https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?v=MN908947.3:21568:T:A\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">MN908947.3:21568:T:A</a>
+        </p>"
+`;
 
 exports[`ProtvistaVariationAdapter should transform the data adequately 1`] = `
 Object {
@@ -250,7 +255,10 @@ Object {
                 
                 
                 
-                <h5>Ensembl COVID-19</h5><p><a href=\\"https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?v=MN908947.3:21568:T:A\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">MN908947.3:21568:T:A</a></p>
+                <h5>Ensembl COVID-19</h5>
+          <p>
+          <a href=\\"https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?v=MN908947.3:21568:T:A\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">MN908947.3:21568:T:A</a>
+        </p>
                 
         ",
       "type": "VARIANT",

--- a/packages/protvista-variation-adapter/test/__snapshots__/ProtvistaVariationAdapter.spec.js.snap
+++ b/packages/protvista-variation-adapter/test/__snapshots__/ProtvistaVariationAdapter.spec.js.snap
@@ -20,6 +20,10 @@ exports[`ProtvistaVariationAdapter should format population frequencies 1`] = `"
 
 exports[`ProtvistaVariationAdapter should format predictions 1`] = `"<h6>PolyPhen</h6><ul class=\\"no-bullet\\"><li>probably damaging</li></ul>"`;
 
+exports[`ProtvistaVariationAdapter should generate the Ensembl covid link only if present 1`] = `""`;
+
+exports[`ProtvistaVariationAdapter should generate the Ensembl covid link only if present 2`] = `"<h5>Ensembl COVID-19</h5><p><a href=\\"https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?v=MN908947.3:21568:T:A\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">MN908947.3:21568:T:A</a></p>"`;
+
 exports[`ProtvistaVariationAdapter should transform the data adequately 1`] = `
 Object {
   "sequence": "MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKTCIDTKEGILQYCQEVYPELQITNVVEANQPVTIQNWCKRGRKQCKTHPHFVIPYRCLVGEFVSDALLVPDKCKFLHQERMDVCETHLHWHTVAKETCSEKSTNLHDYGMLLPCGIDKFRGVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDKVVEVAEEEEVAEVEEEEADDDEDDEDGDEVEEEAEEPYEEATERTTSIATTTTTTTESVEEVVREVCSEQAETGPCRAMISRWYFDVTEGKCAPFFYGGCGGNRNNFDTEEYCMAVCGSAMSQSLLKTTQEPLARDPVKLPTTAASTPDAVDKYLETPGDENEHAHFQKAKERLEAKHRERMSQVMREWEEAERQAKNLPKADKKAVIQHFQEKVESLEQEAANERQQLVETHMARVEAMLNDRRRLALENYITALQAVPPRPRHVFNMLKKYVRAEQKDRQHTLKHFEHVRMVDPKKAAQIRSQVMTHLRVIYERMNQSLSLLYNVPAVAEEIQDEVDELLQKEQNYSDDVLANMISEPRISYGNDALMPSLTETKTTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDARPAADRGLTTRPGSGLTNIKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITLVMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN",
@@ -181,7 +185,7 @@ Object {
     
           
                 <h6>PolyPhen</h6><ul class=\\"no-bullet\\"><li>probably damaging</li></ul>
-
+                
                 
         ",
       "type": "VARIANT",
@@ -207,6 +211,58 @@ Object {
           "id": "rs529782627",
           "name": "gnomAD",
           "url": " http://gnomad.broadinstitute.org/awesome?query=rs529782627",
+        },
+      ],
+    },
+    Object {
+      "accession": "NC_045512.2:g.21568T>A",
+      "alternativeSequence": "L",
+      "begin": "2",
+      "codon": "TTT/TTA",
+      "consequenceType": "missense",
+      "end": "2",
+      "genomicLocation": "NC_045512.2:g.21568T>A",
+      "hasPredictions": undefined,
+      "locations": Array [
+        Object {
+          "loc": "p.Phe2Leu",
+          "seqId": "ENSSAST00005000004",
+          "source": "EnsemblViruses",
+        },
+        Object {
+          "loc": "c.6T>A",
+          "seqId": "ENSSAST00005000004",
+          "source": "EnsemblViruses",
+        },
+      ],
+      "mutatedType": "L",
+      "protvistaFeatureId": "uuid_id",
+      "somaticStatus": 0,
+      "sourceType": "large_scale_study",
+      "start": "2",
+      "tooltipContent": "
+                <h5>Variant</h5><p>F > L</p>
+                
+                <h5>Consequence</h5><p>missense</p>
+                
+                <h5>Location</h5><p>NC_045512.2:g.21568T>A</p>
+                
+                
+                
+                
+                <h5>Ensembl COVID-19</h5><p><a href=\\"https://covid-19.ensembl.org/Sars_cov_2/Variation/Explore?v=MN908947.3:21568:T:A\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">MN908947.3:21568:T:A</a></p>
+                
+        ",
+      "type": "VARIANT",
+      "variant": "L",
+      "wildType": "F",
+      "xrefNames": Array [
+        "ENA",
+      ],
+      "xrefs": Array [
+        Object {
+          "id": "MN908947.3:21568:T:A",
+          "name": "ENA",
         },
       ],
     },

--- a/packages/protvista-variation-adapter/test/variants.json
+++ b/packages/protvista-variation-adapter/test/variants.json
@@ -156,6 +156,37 @@
           "sources": ["ClinVar"]
         }
       ]
+    },
+    {
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "2",
+      "end": "2",
+      "xrefs": [
+        {
+          "name": "ENA",
+          "id": "MN908947.3:21568:T:A"
+        }
+      ],
+      "genomicLocation": "NC_045512.2:g.21568T>A",
+      "locations": [
+        {
+          "loc": "p.Phe2Leu",
+          "seqId": "ENSSAST00005000004",
+          "source": "EnsemblViruses"
+        },
+        {
+          "loc": "c.6T>A",
+          "seqId": "ENSSAST00005000004",
+          "source": "EnsemblViruses"
+        }
+      ],
+      "codon": "TTT/TTA",
+      "consequenceType": "missense",
+      "wildType": "F",
+      "mutatedType": "L",
+      "somaticStatus": 0,
+      "sourceType": "large_scale_study"
     }
   ]
 }


### PR DESCRIPTION
### Reference to issue
Some variants now have extra information allowing to link to Ensembl COVID-19. This should be displayed in the tooltip.

### Description of changes
Add logic to extract the corresponding id and generate the link.

### Tests / Styleguide
 - [x] Tests pass
 - [x] Styleguide
