### PR TITLE
Filled area chart using "area" field in line plot

### DIFF
--- a/app/src/mocks/line-graph-chart.json
+++ b/app/src/mocks/line-graph-chart.json
@@ -1,7 +1,8 @@
 [
   {
     "name": "chart1",
-    "colour": "#8B0000",
+    "colour": "#0000ee",
+    "fill": "#5555ee",
     "range": [0, 50],
     "values": [
       {

--- a/packages/nightingale-linegraph-track/README.md
+++ b/packages/nightingale-linegraph-track/README.md
@@ -32,8 +32,7 @@ The data expects the following structure.
     range:[min, max],
     colour?: Line colour,
         (Colour will be assigned if not provided. Use "none" for no line colour)
-    fill?: Produce a filled area chart (default false),
-    fillColor?: Fill colour (same as line colour if not provided),
+    fill?: Create area plot using given fill colour (default "none"),
     lineCurve?: 'curveLinear'(default)|'curveBasis'|'curveCardinal'|'curveStep'|'curveNatural',
         (More curves - https://github.com/d3/d3-shape/blob/v2.0.0/README.md#curves)
     values: [

--- a/packages/nightingale-linegraph-track/README.md
+++ b/packages/nightingale-linegraph-track/README.md
@@ -31,6 +31,7 @@ The data expects the following structure.
     name: String,
     range:[min, max],
     colour?: Any colour,
+    area?: Produce a filled area chart (default false),
     lineCurve?: 'curveLinear'(default)|'curveBasis'|'curveCardinal'|'curveStep'|'curveNatural',
         (More curves - https://github.com/d3/d3-shape/blob/v2.0.0/README.md#curves)
     values: [

--- a/packages/nightingale-linegraph-track/README.md
+++ b/packages/nightingale-linegraph-track/README.md
@@ -30,8 +30,10 @@ The data expects the following structure.
 {
     name: String,
     range:[min, max],
-    colour?: Any colour,
-    area?: Produce a filled area chart (default false),
+    colour?: Line colour,
+        (Colour will be assigned if not provided. Use "none" for no line colour)
+    fill?: Produce a filled area chart (default false),
+    fillColor?: Fill colour (same as line colour if not provided),
     lineCurve?: 'curveLinear'(default)|'curveBasis'|'curveCardinal'|'curveStep'|'curveNatural',
         (More curves - https://github.com/d3/d3-shape/blob/v2.0.0/README.md#curves)
     values: [

--- a/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.js
+++ b/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.js
@@ -192,11 +192,11 @@ class NightingaleLinegraphTrack extends ProtvistaTrack {
   drawLine(d) {
     const curve = d.lineCurve || "curveLinear";
 
-    var graph;
+    let graph;
     if (d.area) {
       graph = area()
         .y1((d) => this._yScale(d.value))
-        .y0((d) => this._yScale(0))
+        .y0(() => this._yScale(0))
     } else {
       graph = line()
         .y((d) => this._yScale(d.value))

--- a/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.js
+++ b/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.js
@@ -1,6 +1,6 @@
 import ProtvistaTrack from "protvista-track";
 import * as d3 from "d3";
-import { scaleLinear, select, line, max, min, interpolateRainbow } from "d3";
+import { scaleLinear, select, line, area, max, min, interpolateRainbow } from "d3";
 
 class NightingaleLinegraphTrack extends ProtvistaTrack {
   connectedCallback() {
@@ -59,8 +59,8 @@ class NightingaleLinegraphTrack extends ProtvistaTrack {
         d.colour = d.colour || interpolateRainbow(Math.random()); // eslint-disable-line no-param-reassign
         return this.drawLine(d)(d.values);
       })
-      .attr("fill", "none")
-      .attr("stroke", (d) => d.colour)
+      .attr("fill", (d) => d.area ? d.colour : "none")
+      .attr("stroke", (d) => d.area ? "none" : d.colour)
       .attr("transform", "translate(0,0)");
 
     const mouseG = this.chartGroup
@@ -192,14 +192,23 @@ class NightingaleLinegraphTrack extends ProtvistaTrack {
   drawLine(d) {
     const curve = d.lineCurve || "curveLinear";
 
-    return line()
+    var graph;
+    if (d.area) {
+      graph = area()
+        .y1((d) => this._yScale(d.value))
+        .y0((d) => this._yScale(0))
+    } else {
+      graph = line()
+        .y((d) => this._yScale(d.value))
+    }
+
+    return graph
       .defined((d) => d.value !== null) // To have gaps in the line graph
       .x(
         (d) =>
           this.getXFromSeqPosition(d.position + 1) -
           this.getSingleBaseWidth() / 2
       )
-      .y((d) => this._yScale(d.value))
       .curve(d3[curve]);
   }
 }

--- a/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.js
+++ b/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.js
@@ -57,10 +57,10 @@ class NightingaleLinegraphTrack extends ProtvistaTrack {
       .attr("id", (d) => d.name)
       .attr("d", (d) => {
         d.colour = d.colour || interpolateRainbow(Math.random()); // eslint-disable-line no-param-reassign
-        d.fillColor = d.fillColor || d.colour
+        d.fill = d.fill || "none"
         return this.drawLine(d)(d.values);
       })
-      .attr("fill", (d) => d.fill ? d.fillColor : "none")
+      .attr("fill", (d) => d.fill)
       .attr("stroke", (d) => d.colour)
       .attr("transform", "translate(0,0)");
 
@@ -194,7 +194,7 @@ class NightingaleLinegraphTrack extends ProtvistaTrack {
     const curve = d.lineCurve || "curveLinear";
 
     let graph;
-    if (d.fill) {
+    if (d.fill != "none") {
       graph = area()
         .y1((d) => this._yScale(d.value))
         .y0(() => this._yScale(0))

--- a/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.js
+++ b/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.js
@@ -57,10 +57,11 @@ class NightingaleLinegraphTrack extends ProtvistaTrack {
       .attr("id", (d) => d.name)
       .attr("d", (d) => {
         d.colour = d.colour || interpolateRainbow(Math.random()); // eslint-disable-line no-param-reassign
+        d.fillColor = d.fillColor || d.colour
         return this.drawLine(d)(d.values);
       })
-      .attr("fill", (d) => d.area ? d.colour : "none")
-      .attr("stroke", (d) => d.area ? "none" : d.colour)
+      .attr("fill", (d) => d.fill ? d.fillColor : "none")
+      .attr("stroke", (d) => d.colour)
       .attr("transform", "translate(0,0)");
 
     const mouseG = this.chartGroup
@@ -193,7 +194,7 @@ class NightingaleLinegraphTrack extends ProtvistaTrack {
     const curve = d.lineCurve || "curveLinear";
 
     let graph;
-    if (d.area) {
+    if (d.fill) {
       graph = area()
         .y1((d) => this._yScale(d.value))
         .y0(() => this._yScale(0))


### PR DESCRIPTION
Use `fill: true` in line plot to produce a filled area chart

Implements https://github.com/ebi-webcomponents/nightingale/issues/149

![image](https://user-images.githubusercontent.com/2894124/117779612-1e8a5c80-b23f-11eb-8cfc-de64d9f98689.png)
