### PR TITLE
sequence-textarea: disable-header-check

### DIFF
--- a/app/src/components/TextareaSequence.jsx
+++ b/app/src/components/TextareaSequence.jsx
@@ -7,6 +7,11 @@ import readmeContent from "../../../packages/textarea-sequence/README.md";
 const ProtvistaNavigationWrapper = () => {
   const element = useRef(null);
   const [errors, setErrors] = useState({});
+  const [flags, setFlags] = useState({
+    single: true,
+    comments: true,
+    checkHeader: true,
+  });
   const [valid, setValid] = useState(true);
   useEffect(() => {
     element.current.addEventListener("error-change", (e) => {
@@ -15,6 +20,12 @@ const ProtvistaNavigationWrapper = () => {
     });
   }, []);
   loadWebComponent("textarea-sequence", TextareaSequence);
+  const toggleFlag = (flag) => () => {
+    setFlags({
+      ...flags,
+      [flag]: !flags[flag],
+    });
+  };
   return (
     <>
       <h1>textarea-sequence</h1>
@@ -22,11 +33,40 @@ const ProtvistaNavigationWrapper = () => {
         ref={element}
         height="10em"
         min-sequence-length="10"
-        single="true"
-        allow-comments="true"
+        single={flags.single}
+        allow-comments={flags.comments}
         name="example-sequence"
         inner-style="letter-spacing: .01rem;"
+        disable-header-check={flags.checkHeader}
       />
+      <div>
+        <label>
+          <code>single</code>
+          <input
+            type="checkbox"
+            checked={flags.single}
+            onChange={toggleFlag("single")}
+          />
+        </label>
+        <br />
+        <label>
+          <code>allow-comments</code>
+          <input
+            type="checkbox"
+            checked={flags.comments}
+            onChange={toggleFlag("comments")}
+          />
+        </label>
+        <br />
+        <label>
+          <code>disable-header-check</code>
+          <input
+            type="checkbox"
+            checked={flags.checkHeader}
+            onChange={toggleFlag("checkHeader")}
+          />
+        </label>
+      </div>
       <button disabled={valid} onClick={() => element.current.cleanUp()}>
         CleanUp Sequence
       </button>

--- a/packages/textarea-sequence/README.md
+++ b/packages/textarea-sequence/README.md
@@ -55,6 +55,15 @@ Indicates if the textarea should only allow a single sequence
 type: `boolean`
 defaultValue: `false`
 
+##### `disable-header-check`
+
+Indicates if the checks against the alphabet should consider the absence of the header.
+This will only makes sense if the attribute `single` is also `true`, if it's not, the value of
+the error `headerCheckRequiredForMultipleSequences` will be true.
+
+type: `boolean`
+defaultValue: `false`
+
 ##### `min-sequence-length`
 
 Defines the minimum number of bases required in the textarea
@@ -114,6 +123,7 @@ Example:
   missingFirstHeader: false,
   multipleSequences: false,
   tooShort: true, // The current sequence is too short
+  headerCheckRequiredForMultipleSequences: false,
 }
 ```
 

--- a/packages/textarea-sequence/src/TextareaSequence.js
+++ b/packages/textarea-sequence/src/TextareaSequence.js
@@ -9,6 +9,7 @@ class TextareaSequence extends HTMLElement {
     this["min-sequence-length"] = 1;
     this["case-sensitive"] = false;
     this["allow-comments"] = false;
+    this["disable-header-check"] = false;
     this.single = false;
   }
 
@@ -26,11 +27,17 @@ class TextareaSequence extends HTMLElement {
       "min-sequence-length",
       "allow-comments",
       "inner-style",
+      "disable-header-check",
     ];
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    const flags = ["single", "case-sensitive", "allow-comments"];
+    const flags = [
+      "single",
+      "case-sensitive",
+      "allow-comments",
+      "disable-header-check",
+    ];
     const innerDiv = this._getInnerDiv();
     if (!innerDiv || !this.quill) {
       requestAnimationFrame(() =>
@@ -125,7 +132,8 @@ class TextareaSequence extends HTMLElement {
       this.single,
       this["min-sequence-length"],
       this["allow-comments"],
-      formatSequence
+      formatSequence,
+      this["disable-header-check"]
     );
     this.quill.on("text-change", () => {
       this.querySelector(`input[name=${name}]`).value = this.sequence;

--- a/packages/textarea-sequence/src/defaults.js
+++ b/packages/textarea-sequence/src/defaults.js
@@ -38,6 +38,7 @@ export const cleanUpText = (
   caseSensitive = false,
   removeComments = true,
   single = true,
+  disableHeaderCheck = false,
   format = formatSequence
 ) => {
   const sequences = [];
@@ -46,7 +47,9 @@ export const cleanUpText = (
   // Add a header if missing one
   if (!text.trim().startsWith(">")) {
     sequences.push({
-      header: `Generated Header [${Math.round(10000 * Math.random())}]`,
+      header: disableHeaderCheck
+        ? ""
+        : `Generated Header [${Math.round(10000 * Math.random())}]`,
       sequence: "",
       comments: {},
     });
@@ -85,7 +88,10 @@ export const cleanUpText = (
   return (single ? sequences.slice(0, 1) : sequences)
     .map(
       ({ header, sequence, comments }) =>
-        `> ${header}\n${injectComments(format(sequence), comments)}`
+        `${header ? `> ${header}\n` : ""}${injectComments(
+          format(sequence),
+          comments
+        )}`
     )
     .join("\n\n");
   // return newText;

--- a/packages/textarea-sequence/src/quill.test.js
+++ b/packages/textarea-sequence/src/quill.test.js
@@ -59,7 +59,13 @@ describe("textarea-sequence: cleanUpText", () => {
   test("lines of 10 blocks of 5: formatting function", () => {
     const cleaned2 = "> header\nAAAAAAAAAAAAAAAAAAAAA";
     expect(
-      cleanUpText(seq, alphabets.protein, false, true, false, (x) => x)
+      cleanUpText(seq, alphabets.protein, false, true, false, false, (x) => x)
     ).toEqual(cleaned2);
+  });
+  test("diable check header", () => {
+    const seq = "AAAAAAAAAAAAAAAAAAAAA";
+    expect(
+      cleanUpText(seq, alphabets.protein, false, true, false, true)
+    ).toEqual("AAAAAAAAAA AAAAAAAAAA A");
   });
 });


### PR DESCRIPTION
### Description of changes
Adding the attribute `disable-header-check` to the `textarea-sequence` component. So it is possible to clean up a single sequence without adding the generated header.

### Tests / Styleguide
 - [x] Tests pass
 - [x] Styleguide
