### PR TITLE
Remove return type annotation on protvista-structure height setter

### DIFF
--- a/packages/protvista-structure/src/protvista-structure.ts
+++ b/packages/protvista-structure/src/protvista-structure.ts
@@ -139,10 +139,11 @@ class ProtvistaStructure extends HTMLElement implements NightingaleElement {
     return this.getAttribute("height");
   }
 
-  set height(height: string): string {
+  set height(height: string) {
     this.setAttribute("height", height);
     this._height = height;
   }
+
   updateUrls(): void {
     this._uniProtMappingUrl =
       this.getAttribute("uniprot-mapping-url") || this._uniProtMappingUrl;


### PR DESCRIPTION
This was an oversight on the original PR related to #202.
