### PR TITLE
Add test case for structure mapping between chains

### DIFF
--- a/packages/protvista-structure/src/__test__/__mocks__/mapping-test-cases.js
+++ b/packages/protvista-structure/src/__test__/__mocks__/mapping-test-cases.js
@@ -43,6 +43,19 @@ const testCases = [
   {
     entry: "1AAP",
     pdb: {
+      start: 10,
+      end: 100,
+    },
+    uniprot: {
+      start: 10,
+      end: 100,
+    },
+    error: "Start or end coordinate outside of mapping range",
+    mappings: mappings.different_chains,
+  },
+  {
+    entry: "1AAP",
+    pdb: {
       start: 49,
       end: 53,
     },

--- a/packages/protvista-structure/src/__test__/__mocks__/mappings.js
+++ b/packages/protvista-structure/src/__test__/__mocks__/mappings.js
@@ -109,6 +109,42 @@ const mappings = {
       struct_asym_id: "A",
     },
   ],
+  different_chains: [
+    {
+      entity_id: 1,
+      end: {
+        author_residue_number: 50,
+        author_insertion_code: "",
+        residue_number: 50,
+      },
+      chain_id: "A",
+      start: {
+        author_residue_number: 1,
+        author_insertion_code: "",
+        residue_number: 1,
+      },
+      unp_end: 50,
+      unp_start: 1,
+      struct_asym_id: "A",
+    },
+    {
+      entity_id: 1,
+      end: {
+        author_residue_number: 150,
+        author_insertion_code: "",
+        residue_number: 150,
+      },
+      chain_id: "B",
+      start: {
+        author_residue_number: 51,
+        author_insertion_code: "",
+        residue_number: 51,
+      },
+      unp_end: 150,
+      unp_start: 51,
+      struct_asym_id: "B",
+    },
+  ],
 };
 
 export default mappings;

--- a/packages/protvista-structure/src/position-mapping.ts
+++ b/packages/protvista-structure/src/position-mapping.ts
@@ -91,6 +91,8 @@ const translatePositions = (
       const direction = mappingDirection === "UP_PDB" ? 1 : -1;
       return {
         entity: startMapping.entity_id,
+        // Note that we iterate through mappings from one chain at a time,
+        // so all mappings are guaranteed to come from the same chain
         chain: startMapping.chain_id,
         start:
           start +


### PR DESCRIPTION
Turns out that trying to select a region across two chains already shows an error "Start or end coordinate outside of mapping range". This is because the mappings are processed separately for each chain:

https://github.com/ebi-webcomponents/nightingale/blob/master/packages/protvista-structure/src/position-mapping.ts#L55-L61

I added a test case demonstrating this behavior.