### PR TITLE
Add use-ctrl-to-zoom for protvista-structure

### DIFF
--- a/app/src/components/ProtvistaStructure.jsx
+++ b/app/src/components/ProtvistaStructure.jsx
@@ -140,6 +140,15 @@ const ProtvistaStructureWrapper = () => {
         uniprot-mapping-url="https://www.ebi.ac.uk/pdbe/api/mappings/uniprot/"
         custom-download-url="https://files.rcsb.org/download/"
       />
+
+      <h3>
+        Zoom using ctrl key + scroll (avoids interruptions when scrolling page)
+      </h3>
+      <protvista-structure
+        structureid="5ELI"
+        accession="Q9NZC2"
+        use-ctrl-to-zoom
+      />
     </Fragment>
   );
 };

--- a/packages/protvista-structure/README.md
+++ b/packages/protvista-structure/README.md
@@ -46,6 +46,6 @@ Optional custom URL for fetching the mapping from PDB to UniProt. The lowercase 
 
 Optional custom URL for fetching the AlphaFold prediction metadata and mapping. The AlphaFold structure ID is appended here.
 
-#### `custom-download-url`
+#### `use-ctrl-to-zoom`
 
-Optional custom URL for downloading cif structure files. The lowercase PDB ID is appended to it, including `.cif` suffix.
+Analogous to `protvista-zoomable`, use control key when scrolling to zoom the viewer

--- a/packages/protvista-structure/README.md
+++ b/packages/protvista-structure/README.md
@@ -46,6 +46,10 @@ Optional custom URL for fetching the mapping from PDB to UniProt. The lowercase 
 
 Optional custom URL for fetching the AlphaFold prediction metadata and mapping. The AlphaFold structure ID is appended here.
 
+#### `custom-download-url`
+
+Optional custom URL for downloading cif structure files. The lowercase PDB ID is appended to it, including `.cif` suffix.
+
 #### `use-ctrl-to-zoom`
 
 Analogous to `protvista-zoomable`, use control key when scrolling to zoom the viewer

--- a/packages/protvista-structure/src/protvista-structure.ts
+++ b/packages/protvista-structure/src/protvista-structure.ts
@@ -180,7 +180,8 @@ class ProtvistaStructure extends HTMLElement implements NightingaleElement {
     this.appendChild(structureViewerDiv);
     this._structureViewer = new StructureViewer(
       structureViewerDiv,
-      this.propagateHighlight
+      this.propagateHighlight,
+      this.hasAttribute("use-ctrl-to-zoom")
     );
   }
 

--- a/packages/protvista-structure/src/structure-viewer.ts
+++ b/packages/protvista-structure/src/structure-viewer.ts
@@ -54,7 +54,8 @@ class StructureViewer {
     elementOrId: string | HTMLElement,
     onHighlightClick: (
       sequencePositions: { chain: string; position: number }[]
-    ) => void
+    ) => void,
+    useCtrlToZoom: boolean
   ) {
     const defaultSpec = DefaultPluginUISpec(); // TODO: Make our own to select only essential plugins
     const spec: PluginSpec = {
@@ -120,13 +121,33 @@ class StructureViewer {
         onHighlightClick([{ position: sequencePosition, chain: chain }]);
       }
     });
-
     PluginCommands.Canvas3D.SetSettings(this.plugin, {
       settings: (props) => {
         // eslint-disable-next-line no-param-reassign
         props.renderer.backgroundColor = Color(0xffffff);
       },
     });
+    if (useCtrlToZoom) {
+      // Add ctrl key modifier to scroll zoom trigger
+      PluginCommands.Canvas3D.SetSettings(this.plugin, {
+        settings: (props) => {
+          // eslint-disable-next-line no-param-reassign
+          props.trackball.bindings.scrollZoom.triggers[0].modifiers.control =
+            true;
+        },
+      });
+      // Do not always prevent scrolling, only prevent it if ctrl key is pressed
+      this.plugin.canvas3dContext.input.noScroll = false;
+      element.addEventListener(
+        "wheel",
+        (event) => {
+          if (event.ctrlKey) {
+            event.preventDefault();
+          }
+        },
+        false
+      );
+    }
   }
 
   clear(message?: string): void {


### PR DESCRIPTION
### Reference to issue

https://github.com/ebi-webcomponents/nightingale/issues/216

### Description of changes

- Added support for `use-ctrl-to-zoom` attribute to protvista-structure 
- When enabled, molstar zoom binding is configured to require ctrl key to be pressed. Molstar documentation then shows this in Controls info window
- Added example to gallery

<img width="1343" alt="image" src="https://user-images.githubusercontent.com/2894124/199430776-ff61934b-d912-499c-acd3-3d051c0ea3a8.png">