### PR TITLE
Handle async init of molstar

### DIFF
--- a/packages/protvista-structure/src/structure-viewer.ts
+++ b/packages/protvista-structure/src/structure-viewer.ts
@@ -121,33 +121,35 @@ class StructureViewer {
         onHighlightClick([{ position: sequencePosition, chain: chain }]);
       }
     });
-    PluginCommands.Canvas3D.SetSettings(this.plugin, {
-      settings: (props) => {
-        // eslint-disable-next-line no-param-reassign
-        props.renderer.backgroundColor = Color(0xffffff);
-      },
+    const that = this;
+    this.plugin.behaviors.canvas3d.initialized.subscribe((v) => {
+      if (v) {
+        PluginCommands.Canvas3D.SetSettings(that.plugin, {
+          settings: (props) => {
+            // eslint-disable-next-line no-param-reassign
+            props.renderer.backgroundColor = Color(0xffffff);
+            if (useCtrlToZoom) {
+              // Add ctrl key modifier to scroll zoom trigger
+              props.trackball.bindings.scrollZoom.triggers[0].modifiers.control =
+                true;
+            }
+          },
+        });
+        if (useCtrlToZoom) {
+          // Do not always prevent scrolling, only prevent it if ctrl key is pressed
+          that.plugin.canvas3dContext.input.noScroll = false;
+          element.addEventListener(
+            "wheel",
+            (event) => {
+              if (event.ctrlKey) {
+                event.preventDefault();
+              }
+            },
+            false
+          );
+        }
+      }
     });
-    if (useCtrlToZoom) {
-      // Add ctrl key modifier to scroll zoom trigger
-      PluginCommands.Canvas3D.SetSettings(this.plugin, {
-        settings: (props) => {
-          // eslint-disable-next-line no-param-reassign
-          props.trackball.bindings.scrollZoom.triggers[0].modifiers.control =
-            true;
-        },
-      });
-      // Do not always prevent scrolling, only prevent it if ctrl key is pressed
-      this.plugin.canvas3dContext.input.noScroll = false;
-      element.addEventListener(
-        "wheel",
-        (event) => {
-          if (event.ctrlKey) {
-            event.preventDefault();
-          }
-        },
-        false
-      );
-    }
   }
 
   clear(message?: string): void {

--- a/packages/protvista-structure/src/structure-viewer.ts
+++ b/packages/protvista-structure/src/structure-viewer.ts
@@ -121,10 +121,9 @@ class StructureViewer {
         onHighlightClick([{ position: sequencePosition, chain: chain }]);
       }
     });
-    const that = this;
     this.plugin.behaviors.canvas3d.initialized.subscribe((v) => {
       if (v) {
-        PluginCommands.Canvas3D.SetSettings(that.plugin, {
+        PluginCommands.Canvas3D.SetSettings(this.plugin, {
           settings: (props) => {
             // eslint-disable-next-line no-param-reassign
             props.renderer.backgroundColor = Color(0xffffff);
@@ -137,7 +136,7 @@ class StructureViewer {
         });
         if (useCtrlToZoom) {
           // Do not always prevent scrolling, only prevent it if ctrl key is pressed
-          that.plugin.canvas3dContext.input.noScroll = false;
+          this.plugin.canvas3dContext.input.noScroll = false;
           element.addEventListener(
             "wheel",
             (event) => {


### PR DESCRIPTION
In our app I discovered that there are race conditions with configuring the structure viewer.

In StructureViewer constructor, this line sometimes fails because the molstar plugin has not been initialized yet:
https://github.com/ebi-webcomponents/nightingale/blob/v3/packages/protvista-structure/src/structure-viewer.ts#L139-L140

This PR solves this by wrapping that piece of code into a callback that's executed when molstar canvas is initialized.