### PR TITLE
Revert rounding of xAxis

### DIFF
--- a/packages/nightingale-sequence/src/nightingale-sequence.ts
+++ b/packages/nightingale-sequence/src/nightingale-sequence.ts
@@ -187,12 +187,7 @@ class NightingaleSequence extends withManager(
 
       // only add axis if there is room
       if (this.height > (this.chWidth || 0) && this.xScale) {
-        // Copying the scale, and rounding its domain values to avoid bug releated with floats
-        const roundScale = this.xScale.copy();
-        roundScale.domain(
-          roundScale.domain().map((i: number) => Math.round(i))
-        );
-        const xAxis = axisBottom(roundScale)
+        const xAxis = axisBottom(this.xScale)
           .tickFormat((d) => `${Number.isInteger(d) ? d : ""}`)
           .ticks(this.numberOfTicks, "s");
         this.#axis.call(xAxis);


### PR DESCRIPTION
While the rounding fixes the missing ticks on the sole sequence component without causing any further issues while isolated, I did notice it causes issues in the manager component since it affects the exact position of a tick there as the sequence doesn't have to start or end at a rounded number.
Only in its isolated state when using an integer starting point, the floating point error will become noticeable.