### PR TITLE
Adding zoom methods to navigation

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "4.0.5-alpha.0"
+  "version": "4.0.6-alpha.0"
 }

--- a/packages/nightingale-coloured-sequence/package.json
+++ b/packages/nightingale-coloured-sequence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nightingale-elements/nightingale-coloured-sequence",
-  "version": "4.0.5-alpha.0",
+  "version": "4.0.6-alpha.0",
   "description": "Track that colors each base by a given function. The default function is hydrophobicity",
   "files": [
     "dist",
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@nightingale-elements/nightingale-new-core": "^4.0.5-alpha.0",
-    "@nightingale-elements/nightingale-sequence": "^4.0.5-alpha.0",
+    "@nightingale-elements/nightingale-sequence": "^4.0.6-alpha.0",
     "d3": "7.6.1"
   },
   "repository": {

--- a/packages/nightingale-coloured-sequence/src/nightingale-coloured-sequence.ts
+++ b/packages/nightingale-coloured-sequence/src/nightingale-coloured-sequence.ts
@@ -109,11 +109,7 @@ class NightingaleColouredSequence extends NightingaleSequence {
 
   renderD3() {
     if (this.seq_g) {
-      this.svg = select(this as unknown as NightingaleElement)
-        .selectAll<SVGSVGElement, unknown>("svg")
-        .attr("id", "")
-        .attr("width", this.width)
-        .attr("height", this.height);
+      this.svg?.attr("width", this.width).attr("height", this.height);
 
       this.seq_g.attr("width", this.width);
 

--- a/packages/nightingale-coloured-sequence/src/nightingale-coloured-sequence.ts
+++ b/packages/nightingale-coloured-sequence/src/nightingale-coloured-sequence.ts
@@ -1,12 +1,10 @@
 import { customElement, property } from "lit/decorators.js";
-import { scaleLinear, Selection, select } from "d3";
+import { scaleLinear, Selection } from "d3";
 
 import NightingaleSequence, {
   SequenceBaseType,
 } from "@nightingale-elements/nightingale-sequence";
-import NightingaleElement, {
-  bindEvents,
-} from "@nightingale-elements/nightingale-new-core";
+import { bindEvents } from "@nightingale-elements/nightingale-new-core";
 
 import ColorScaleParser from "./utils/ColorScaleParser";
 import String2Object from "./utils/String2Object";

--- a/packages/nightingale-interpro-track/package.json
+++ b/packages/nightingale-interpro-track/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nightingale-elements/nightingale-interpro-track",
-  "version": "4.0.5-alpha.0",
+  "version": "4.0.6-alpha.0",
   "description": "Interpro extension of the track type.",
   "files": [
     "dist",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@nightingale-elements/nightingale-new-core": "^4.0.5-alpha.0",
-    "@nightingale-elements/nightingale-track": "^4.0.5-alpha.0",
+    "@nightingale-elements/nightingale-track": "^4.0.6-alpha.0",
     "d3": "7.6.1",
     "lodash-es": "^4.17.15"
   }

--- a/packages/nightingale-linegraph-track/package.json
+++ b/packages/nightingale-linegraph-track/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nightingale-elements/nightingale-linegraph-track",
   "description": "Nightingale Line Graph",
-  "version": "4.0.5-alpha.0",
+  "version": "4.0.6-alpha.0",
   "files": [
     "dist",
     "src"

--- a/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.ts
+++ b/packages/nightingale-linegraph-track/src/nightingale-linegraph-track.ts
@@ -291,9 +291,7 @@ class NightingaleLinegraphTrack extends withManager(
         .selectAll<SVGPathElement, LineData>("path.graph")
         .attr("d", (d) => this.drawLine(d)(d.values));
 
-      this.svg = select(this as unknown as NightingaleElement)
-        .selectAll<SVGSVGElement, unknown>("svg")
-        .attr("width", this.width);
+      this.svg?.attr("width", this.width);
 
       this.updateHighlight();
 

--- a/packages/nightingale-navigation/README.md
+++ b/packages/nightingale-navigation/README.md
@@ -28,9 +28,27 @@ The scale of coordinates will start from this value.
 
 a horizontal padding to add on the ruler, to give the component a zooming efect even when the whole sequence is selected
 
+#### `scale-factor: number (default 10)`
+
+The quanity use to scale in or out when using the methods `zoomIn` or `zoomOut`
+
 #### `show-highlight: boolean (default false)`
 
 A shade representing a highlighted area can be added over the component.
+
+### Methods
+
+#### `locate(start: number, end: number)`
+
+Locates the selected area of the navigation component triggering the events related to it.
+
+#### `zoomIn()`
+
+Reduces the selected area of the navigation component by the quantity specified in the `scale-factor` attribute.
+
+#### `zoomOut()`
+
+Extends the selected area of the navigation component by the quantity specified in the `scale-factor` attribute.
 
 ### Other attributes and parameters
 

--- a/packages/nightingale-navigation/package.json
+++ b/packages/nightingale-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nightingale-elements/nightingale-navigation",
-  "version": "4.0.5-alpha.0",
+  "version": "4.0.6-alpha.0",
   "description": "Navigation component for the Nightingale tool",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/nightingale-navigation/src/nightingale-navigation.ts
+++ b/packages/nightingale-navigation/src/nightingale-navigation.ts
@@ -67,6 +67,8 @@ class NightingaleNavigation extends withManager(
   "ruler-start" = 1;
   @property({ type: Number })
   "ruler-padding" = 10;
+  @property({ type: Number })
+  "scale-factor" = (this.length || 0) / 5 || 10;
   @property({ type: Boolean })
   "show-highlight" = false;
 
@@ -220,6 +222,33 @@ class NightingaleNavigation extends withManager(
       this.updateHighlight();
       this.renderMarginOnGroup(this.#margins);
     }
+  }
+
+  locate(start: number, end: number) {
+    if (this.#brushG && this.#viewport && this.#x)
+      this.#brushG.call(this.#viewport.move, [this.#x(start), this.#x(end)]);
+  }
+  zoomOut() {
+    this.locate(
+      Math.max(
+        this["ruler-start"] || 1,
+        this.getStart() - this["scale-factor"]
+      ),
+      Math.min(
+        (this.length || 1) + this["ruler-start"] - 1,
+        this.getEnd() + this["scale-factor"]
+      )
+    );
+  }
+  zoomIn() {
+    const newStart = Math.min(
+      this.getStart() + this["scale-factor"],
+      this.getEnd() - 1
+    );
+    this.locate(
+      newStart,
+      Math.max(this.getEnd() - this["scale-factor"], newStart + 1)
+    );
   }
   protected updateHighlight() {
     if (!this.#highlighted) return;

--- a/packages/nightingale-new-core/src/mixins/withZoom/index.ts
+++ b/packages/nightingale-new-core/src/mixins/withZoom/index.ts
@@ -1,3 +1,4 @@
+import { property } from "lit/decorators.js";
 import {
   scaleLinear,
   zoom as d3zoom,
@@ -43,6 +44,9 @@ const withZoom = <T extends Constructor<NightingaleBaseElement>>(
     _zoom?: ZoomBehavior<HTMLElement, unknown>;
     _svg?: Selection<HTMLElement, unknown, HTMLElement, unknown>;
     dontDispatch?: boolean;
+
+    @property({ type: Boolean })
+    "use-ctrl-to-zoom" = false;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(...args: any[]) {
@@ -124,15 +128,15 @@ const withZoom = <T extends Constructor<NightingaleBaseElement>>(
           [0, 0],
           [this.getWidthWithMargins(), 0],
         ])
-        // TODO: deal with events
-        // .filter(() => {
-        //   if (!(d3Event instanceof WheelEvent)) return true;
-        //   if (this.hasAttribute("scroll-filter")) {
-        //     const scrollableAttribute = this.getAttribute("scrollable");
-        //     if (scrollableAttribute) return scrollableAttribute === "true";
-        //   }
-        //   return !this.hasAttribute("use-ctrl-to-zoom") || d3Event.ctrlKey;
-        // })
+        .filter((event) => {
+          if (!(event.type === "wheel")) return true;
+          // TODO: deal with event filters
+          //   if (this.hasAttribute("scroll-filter")) {
+          //     const scrollableAttribute = this.getAttribute("scrollable");
+          //     if (scrollableAttribute) return scrollableAttribute === "true";
+          //   }
+          return !this["use-ctrl-to-zoom"] || event.ctrlKey;
+        })
         .on("zoom", this.zoomed);
     }
 

--- a/packages/nightingale-sequence/package.json
+++ b/packages/nightingale-sequence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nightingale-elements/nightingale-sequence",
-  "version": "4.0.5-alpha.0",
+  "version": "4.0.6-alpha.0",
   "description": "Sequence component for the Nightingale tool",
   "files": [
     "dist",

--- a/packages/nightingale-sequence/src/nightingale-sequence.ts
+++ b/packages/nightingale-sequence/src/nightingale-sequence.ts
@@ -160,11 +160,7 @@ class NightingaleSequence extends withManager(
   renderD3() {
     this.getCharSize();
 
-    this.svg = select(this as unknown as NightingaleElement)
-      .selectAll<SVGSVGElement, unknown>("svg")
-      .attr("id", "")
-      .attr("width", this.width)
-      .attr("height", this.height);
+    this.svg?.attr("width", this.width).attr("height", this.height);
 
     if (this.#axis) {
       const ftWidth = this.getSingleBaseWidth();

--- a/packages/nightingale-track/package.json
+++ b/packages/nightingale-track/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nightingale-elements/nightingale-track",
-  "version": "4.0.5-alpha.0",
+  "version": "4.0.6-alpha.0",
   "description": "Basic track type of the viewer.",
   "files": [
     "dist",

--- a/stories/01.Manager/NightingaleManager.stories.ts
+++ b/stories/01.Manager/NightingaleManager.stories.ts
@@ -235,6 +235,17 @@ export const SimpleNoControls = () =>
   html`<h3>Manger with onlinavigation and sequence</h3>
     <nightingale-manager>
       <div style="line-height: 0">
+        <nightingale-navigation
+          id="navigation"
+          height="100"
+          width="800"
+          length=${defaultSequence.length}
+          highlight-color="#EB3BFF22"
+          show-highlight
+        >
+        </nightingale-navigation>
+      </div>
+      <div style="line-height: 0">
         <nightingale-sequence
           sequence=${defaultSequence}
           height="40"

--- a/stories/01.Manager/NightingaleManager.stories.ts
+++ b/stories/01.Manager/NightingaleManager.stories.ts
@@ -105,6 +105,7 @@ const Template: Story<{
           highlight-event="onmouseover"
           highlight-color=${args["highlight-color"]}
           margin-color=${args["margin-color"]}
+          use-ctrl-to-zoom
         >
         </nightingale-sequence>
       </div>
@@ -121,6 +122,7 @@ const Template: Story<{
           highlight-color=${args["highlight-color"]}
           margin-color=${args["margin-color"]}
           scale="hydrophobicity-scale"
+          use-ctrl-to-zoom
         >
         </nightingale-coloured-sequence>
       </div>
@@ -135,6 +137,7 @@ const Template: Story<{
           highlight-event="onmouseover"
           highlight-color=${args["highlight-color"]}
           margin-color=${args["margin-color"]}
+          use-ctrl-to-zoom
         >
         </nightingale-track>
       </div>
@@ -150,6 +153,7 @@ const Template: Story<{
           highlight-color=${args["highlight-color"]}
           margin-color=${args["margin-color"]}
           layout="non-overlapping"
+          use-ctrl-to-zoom
         >
         </nightingale-track>
       </div>
@@ -166,6 +170,7 @@ const Template: Story<{
           margin-color=${args["margin-color"]}
           shape="roundRectangle"
           label=".feature.name"
+          use-ctrl-to-zoom
           show-label
           expanded
         >
@@ -182,6 +187,7 @@ const Template: Story<{
           highlight-event="onmouseover"
           highlight-color=${args["highlight-color"]}
           margin-color=${args["margin-color"]}
+          use-ctrl-to-zoom
         ></nightingale-linegraph-track>
       </div>
     </nightingale-manager>

--- a/stories/01.Manager/NightingaleManager.stories.ts
+++ b/stories/01.Manager/NightingaleManager.stories.ts
@@ -188,8 +188,8 @@ const Template: Story<{
   `;
 };
 
-export const Manager = Template.bind({});
-Manager.args = {
+export const AllTracks = Template.bind({});
+AllTracks.args = {
   "min-width": 500,
   height: 50,
   length: defaultSequence.length,
@@ -199,7 +199,7 @@ Manager.args = {
   "highlight-color": "#EB3BFF22",
   "margin-color": "transparent",
 };
-Manager.play = async () => {
+AllTracks.play = async () => {
   await customElements.whenDefined("nightingale-sequence");
   const sequence = document.getElementById("sequence");
   if (sequence) (sequence as any).fixedHighlight = "10:20";
@@ -230,3 +230,16 @@ Manager.play = async () => {
     (linegraphTrack as any).data = linegraph;
   }
 };
+
+export const SimpleNoControls = () =>
+  html`<h3>Manger with onlinavigation and sequence</h3>
+    <nightingale-manager>
+      <div style="line-height: 0">
+        <nightingale-sequence
+          sequence=${defaultSequence}
+          height="40"
+          width="800"
+          length=${defaultSequence.length}
+        ></nightingale-sequence>
+      </div>
+    </nightingale-manager> `;

--- a/stories/02.Navigation/NightingaleNavigation.stories.mdx
+++ b/stories/02.Navigation/NightingaleNavigation.stories.mdx
@@ -9,7 +9,7 @@ import marginReadme from "../../packages/nightingale-new-core/src/mixins/withMar
 import positionReadme from "../../packages/nightingale-new-core/src/mixins/withPosition/README.md";
 import resizableReadme from "../../packages/nightingale-new-core/src/mixins/withResizable/README.md";
 
-<Meta title="Components/Navigation/Readme" />
+<Meta title="Components/Tracks/Navigation/Readme" />
 
 <Description>{Readme}</Description>
 

--- a/stories/02.Navigation/NightingaleNavigation.stories.mdx
+++ b/stories/02.Navigation/NightingaleNavigation.stories.mdx
@@ -9,7 +9,7 @@ import marginReadme from "../../packages/nightingale-new-core/src/mixins/withMar
 import positionReadme from "../../packages/nightingale-new-core/src/mixins/withPosition/README.md";
 import resizableReadme from "../../packages/nightingale-new-core/src/mixins/withResizable/README.md";
 
-<Meta title="Components/Tracks/Navigation/Readme" />
+<Meta title="Components/Utils/Navigation/Readme" />
 
 <Description>{Readme}</Description>
 

--- a/stories/02.Navigation/NightingaleNavigation.stories.ts
+++ b/stories/02.Navigation/NightingaleNavigation.stories.ts
@@ -3,7 +3,7 @@ import { html } from "lit-html";
 import "../../packages/nightingale-navigation/src/index.ts";
 
 export default {
-  title: "Components/Tracks/Navigation",
+  title: "Components/Utils/Navigation",
 } as Meta;
 
 const Template: Story<{
@@ -48,11 +48,27 @@ DifferentSelection.args = {
   "display-end": 350,
 };
 
-export const NavigationNoControls = () => html`<nightingale-navigation
-  length="456"
-  display-start="143"
-  display-end="400"
-  highlight="23:45"
-  rulerstart="1"
-  height="60"
-/>`;
+export const NavigationNoControls = () => html`
+  <nightingale-navigation
+    id="navigation"
+    length="456"
+    display-start="143"
+    display-end="400"
+    highlight="23:45"
+    rulerstart="1"
+    height="60"
+  ></nightingale-navigation>
+  <div>
+    <button id="zoom-in">Zoom In</button>
+    <button id="zoom-out">Zoom Out</button>
+  </div>
+  <script>
+    const nav = document.getElementById("navigation");
+    document.getElementById("zoom-in").addEventListener("click", () => {
+      nav.zoomIn();
+    });
+    document.getElementById("zoom-out").addEventListener("click", () => {
+      nav.zoomOut();
+    });
+  </script>
+`;

--- a/stories/02.Navigation/NightingaleNavigation.stories.ts
+++ b/stories/02.Navigation/NightingaleNavigation.stories.ts
@@ -3,7 +3,7 @@ import { html } from "lit-html";
 import "../../packages/nightingale-navigation/src/index.ts";
 
 export default {
-  title: "Components/Navigation",
+  title: "Components/Tracks/Navigation",
 } as Meta;
 
 const Template: Story<{

--- a/stories/03.Sequence/NightingaleSequence.stories.mdx
+++ b/stories/03.Sequence/NightingaleSequence.stories.mdx
@@ -10,7 +10,7 @@ import positionReadme from "../../packages/nightingale-new-core/src/mixins/withP
 import resizableReadme from "../../packages/nightingale-new-core/src/mixins/withResizable/README.md";
 import zoomReadme from "../../packages/nightingale-new-core/src/mixins/withZoom/README.md";
 
-<Meta title="Components/Sequence/Readme" />
+<Meta title="Components/Tracks/Sequence/Readme" />
 
 <Description>{Readme}</Description>
 <hr />

--- a/stories/03.Sequence/NightingaleSequence.stories.ts
+++ b/stories/03.Sequence/NightingaleSequence.stories.ts
@@ -3,7 +3,7 @@ import { html } from "lit-html";
 import "../../packages/nightingale-sequence/src/index.ts";
 
 export default {
-  title: "Components/Sequence",
+  title: "Components/Tracks/Sequence",
 } as Meta;
 
 const defaultSequence = "iubcbcIUENACBPAOUBCASFUBRUABBRWOAUVBISVBAISBVDOASV";

--- a/stories/04.ColouredSequence/NightingaleColouredSequence.stories.mdx
+++ b/stories/04.ColouredSequence/NightingaleColouredSequence.stories.mdx
@@ -10,7 +10,7 @@ import positionReadme from "../../packages/nightingale-new-core/src/mixins/withP
 import resizableReadme from "../../packages/nightingale-new-core/src/mixins/withResizable/README.md";
 import zoomReadme from "../../packages/nightingale-new-core/src/mixins/withZoom/README.md";
 
-<Meta title="Components/Coloured Sequence/Readme" />
+<Meta title="Components/Tracks/Coloured Sequence/Readme" />
 
 <Description>{Readme}</Description>
 

--- a/stories/04.ColouredSequence/NightingaleColouredSequence.stories.ts
+++ b/stories/04.ColouredSequence/NightingaleColouredSequence.stories.ts
@@ -10,7 +10,7 @@ const scales = [
   "T:-2,R:-2,Y:-2,F:2,A:2,I:2,L:2",
 ];
 export default {
-  title: "Components/Coloured Sequence",
+  title: "Components/Tracks/Coloured Sequence",
   argTypes: {
     scale: {
       options: scales,

--- a/stories/05.Track/NightingaleTrack.stories.mdx
+++ b/stories/05.Track/NightingaleTrack.stories.mdx
@@ -10,7 +10,7 @@ import positionReadme from "../../packages/nightingale-new-core/src/mixins/withP
 import resizableReadme from "../../packages/nightingale-new-core/src/mixins/withResizable/README.md";
 import zoomReadme from "../../packages/nightingale-new-core/src/mixins/withZoom/README.md";
 
-<Meta title="Components/NightingaleTrack/Readme" />
+<Meta title="Components/Tracks/NightingaleTrack/Readme" />
 
 <Description>{Readme}</Description>
 

--- a/stories/05.Track/NightingaleTrack.stories.ts
+++ b/stories/05.Track/NightingaleTrack.stories.ts
@@ -4,7 +4,7 @@ import "../../packages/nightingale-track/src/index.ts";
 import mockData from "../../packages/nightingale-track/tests/mockData/data.json";
 
 export default {
-  title: "Components/NightingaleTrack",
+  title: "Components/Tracks/NightingaleTrack",
 } as Meta;
 
 const defaultData = [

--- a/stories/06.InterProTrack/NightingaleInterProTrack.stories.mdx
+++ b/stories/06.InterProTrack/NightingaleInterProTrack.stories.mdx
@@ -9,7 +9,7 @@ import positionReadme from "../../packages/nightingale-new-core/src/mixins/withP
 import resizableReadme from "../../packages/nightingale-new-core/src/mixins/withResizable/README.md";
 import zoomReadme from "../../packages/nightingale-new-core/src/mixins/withZoom/README.md";
 
-<Meta title="Components/InterPro Track/Readme" />
+<Meta title="Components/Tracks/InterPro Track/Readme" />
 
 <Description>{Readme}</Description>
 <hr />

--- a/stories/06.InterProTrack/NightingaleInterProTrack.stories.ts
+++ b/stories/06.InterProTrack/NightingaleInterProTrack.stories.ts
@@ -7,7 +7,7 @@ import contributors from "../../packages/nightingale-interpro-track/tests/mockDa
 import residues from "../../packages/nightingale-interpro-track/tests/mockData/interpro-residues.json";
 
 export default {
-  title: "Components/InterPro Track",
+  title: "Components/Tracks/InterPro Track",
 } as Meta;
 
 const Template: Story<{

--- a/stories/07.LineGraph/NightingaleLinegraphTrack.stories.mdx
+++ b/stories/07.LineGraph/NightingaleLinegraphTrack.stories.mdx
@@ -10,7 +10,7 @@ import positionReadme from "../../packages/nightingale-new-core/src/mixins/withP
 import resizableReadme from "../../packages/nightingale-new-core/src/mixins/withResizable/README.md";
 import zoomReadme from "../../packages/nightingale-new-core/src/mixins/withZoom/README.md";
 
-<Meta title="Components/Linegraph Track/Readme" />
+<Meta title="Components/Tracks/Linegraph Track/Readme" />
 
 <Description>{Readme}</Description>
 

--- a/stories/07.LineGraph/NightingaleLinegraphTrack.stories.ts
+++ b/stories/07.LineGraph/NightingaleLinegraphTrack.stories.ts
@@ -3,7 +3,7 @@ import { html } from "lit-html";
 import "../../packages/nightingale-linegraph-track/src/index.ts";
 
 export default {
-  title: "Components/Linegraph Track",
+  title: "Components/Tracks/Linegraph Track",
 } as Meta;
 
 import tinyData from "../../packages/nightingale-linegraph-track/tests/mockData/data.json";


### PR DESCRIPTION
Adds methods to navigation to be able to programmatically change the selected area:
* `locate(start, end)`: sets the navigation selection on the given coordinates.
* `zoomIn()`: decreases the size of the selected area
* `zoomOut()`: increases the size of the selected area.

Fixed #221 avoiding infinity renderings of some components. The issue was that the property `this.svg` was been redifined in some of the `render()` methods, and there is a setter in `withZoom` that triggers a re-render when svg is set.

Re-enables the attribute `use-ctrl-to-zoom`

**Note:** To be reviewed after #231 