### PR TITLE
Minor fix in nightingale-saver

### DIFF
--- a/packages/nightingale-saver/README.md
+++ b/packages/nightingale-saver/README.md
@@ -81,9 +81,10 @@ Number of pixels added to the right of the image in case of any desired horizont
 
 Number of pixels added to the bottom of the image in case of any desired vertical offset
 
-#### `debug: boolean (default: false)`
+#### `preview: boolean (default: false)`
 
 If `true` the generated canvas will be added to the component in order to visually inspect the outcome image.
+The image is not downloaded. 
 
 ### Properties
 

--- a/packages/nightingale-saver/src/nightingale-saver.ts
+++ b/packages/nightingale-saver/src/nightingale-saver.ts
@@ -29,9 +29,6 @@ class NightingaleSaver extends NightingaleElement {
   @property({ type: Boolean })
   preview?: boolean = false;
 
-  #height: number = -1;
-  #width: number = -1;
-
   preSave?: () => void = undefined;
   postSave?: () => void = undefined;
 

--- a/packages/nightingale-saver/src/nightingale-saver.ts
+++ b/packages/nightingale-saver/src/nightingale-saver.ts
@@ -52,15 +52,12 @@ class NightingaleSaver extends NightingaleElement {
     if (typeof this.preSave === "function") {
       this.preSave();
     }
-    if (this.#height < 0 && this.#width < 0) {
-      const { width, height } = element.getBoundingClientRect();
-      this.#width = width;
-      this.#height = height;
-    }
+    element.querySelector('canvas.preview')?.remove();
+    const { width, height } = element.getBoundingClientRect();
 
     const scaleFactor = this.scaleFactor || 1;
-    const scaledWidth = scaleFactor * (this.#width + (this.extraWidth as number));
-    const scaledHeight = scaleFactor * (this.#height + (this.extraHeight as number));
+    const scaledWidth = scaleFactor * (width + (this.extraWidth as number));
+    const scaledHeight = scaleFactor * (height + (this.extraHeight as number));
     const canvas = document.createElement("canvas");
     canvas.className = "preview";
     canvas.setAttribute("width", `${scaledWidth}px`);
@@ -73,7 +70,6 @@ class NightingaleSaver extends NightingaleElement {
       }
     }
     if (this.preview) {
-      element.querySelector('canvas.preview')?.remove();
       element.appendChild(canvas);
     }
 

--- a/stories/08.Saver/NightingaleSaver.stories.ts
+++ b/stories/08.Saver/NightingaleSaver.stories.ts
@@ -13,7 +13,7 @@ const Template: Story<{
   "background-color": string;
   "extra-width": number;
   "extra-height": number;
-  debug: boolean;
+  preview: boolean;
 }> = (args) => {
   return html`<nightingale-navigation
       height="50"
@@ -30,7 +30,7 @@ const Template: Story<{
       background-color=${args["background-color"]}
       extra-width=${args["extra-width"]}
       extra-height=${args["extra-height"]}
-      ?debug=${args.debug}
+      ?preview=${args.preview}
       scale-factor="2"
     >
       <button>Save a Pic! 📸</button>
@@ -44,5 +44,5 @@ Saver.args = {
   "background-color": "#ddddee",
   "extra-width": 0,
   "extra-height": 0,
-  debug: true,
+  preview: true,
 };

--- a/stories/08.Saver/NightingaleSaver.stories.ts
+++ b/stories/08.Saver/NightingaleSaver.stories.ts
@@ -13,6 +13,7 @@ const Template: Story<{
   "background-color": string;
   "extra-width": number;
   "extra-height": number;
+  "scale-factor": number;
   preview: boolean;
 }> = (args) => {
   return html`<nightingale-navigation
@@ -30,8 +31,8 @@ const Template: Story<{
       background-color=${args["background-color"]}
       extra-width=${args["extra-width"]}
       extra-height=${args["extra-height"]}
+      scale-factor=${args["scale-factor"]}
       ?preview=${args.preview}
-      scale-factor="2"
     >
       <button>Save a Pic! 📸</button>
     </nightingale-saver> `;
@@ -44,5 +45,6 @@ Saver.args = {
   "background-color": "#ddddee",
   "extra-width": 0,
   "extra-height": 0,
+  "scale-factor": 2,
   preview: true,
 };


### PR DESCRIPTION
The size of the canvas (on which the image is drawn before being downloaded) is defined as such:

https://github.com/ebi-webcomponents/nightingale/blob/d77b9f52af3e3182a5bd92023ee06135a46f2452/packages/nightingale-saver/src/nightingale-saver.ts#L52

However, when `debug` is `true`, the canvas is added to `element`:

https://github.com/ebi-webcomponents/nightingale/blob/d77b9f52af3e3182a5bd92023ee06135a46f2452/packages/nightingale-saver/src/nightingale-saver.ts#L66

This results in `element` being higher and higher, and the downloaded image as well.

This PR fixes this by storing the initial height/width of `element` in private features.

Three other changes:

- rename `debug` with `preview`
- add the `preview` option to the `nightingale-saver`'s story in storybook
- when `preview` is `true`, only one canvas is added to the component. Any subsequent preview deletes the previous canvas.