### PR TITLE
Feat/nightingale tooltip

### DIFF
--- a/packages/nightingale-manager/src/nightingale-manager.ts
+++ b/packages/nightingale-manager/src/nightingale-manager.ts
@@ -3,155 +3,196 @@ import NightingaleElement from "@nightingale-elements/nightingale-new-core";
 
 @customElement("nightingale-manager")
 class NightingaleManager extends NightingaleElement {
-  @property({
-    converter: {
-      fromAttribute: (value): Map<string, null> | null => {
-        if (!value) {
-          return null;
-        }
-        const attributes = value.split(",");
-        if (attributes.indexOf("type") !== -1)
-          throw new Error("'type' can't be used as a protvista attribute");
-        if (attributes.indexOf("value") !== -1)
-          throw new Error("'value' can't be used as a protvista attribute");
-        const mapToReturn = new Map(
-          attributes
-            .filter(
-              (attr: string) =>
-                !NightingaleManager.observedAttributes.includes(attr),
-            )
-            .map((attr: string) => [attr, null]),
-        );
-        return mapToReturn;
-      },
-      toAttribute: (value: []) => {
-        return value.join(",");
-      },
-    },
-  })
-  "reflected-attributes"?: Map<string, null> = new Map();
+    @property({
+        converter: {
+            fromAttribute: (value): Map<string, null> | null => {
+                if (!value) {
+                    return null;
+                }
+                const attributes = value.split(",");
+                if (attributes.indexOf("type") !== -1) throw new Error("'type' can't be used as a protvista attribute");
+                if (attributes.indexOf("value") !== -1) throw new Error("'value' can't be used as a protvista attribute");
+                const mapToReturn = new Map(attributes.filter((attr: string) => !NightingaleManager.observedAttributes.includes(attr)).map((attr: string) => [attr, null]));
+                return mapToReturn;
+            },
+            toAttribute: (value: []) => {
+                return value.join(",");
+            },
+        },
+    })
+    "reflected-attributes"?: Map<string, null> = new Map();
 
-  @property({ type: Number })
-  length?: number;
+    @property({ type: Number })
+    length?: number;
 
-  @property({ type: Number })
-  "display-start"?: number;
+    @property({ type: Number })
+    "display-start"?: number;
 
-  @property({ type: Number })
-  "display-end"?: number;
+    @property({ type: Number })
+    "display-end"?: number;
 
-  @property({ type: String })
-  "highlight"?: string;
+    @property({ type: String })
+    "highlight"?: string;
 
-  @state()
-  protvistaElements = new Set<HTMLElement>();
+    @state()
+    protvistaElements = new Set<HTMLElement>();
 
-  @state()
-  propertyValues = new Map<string, string>();
+    @state()
+    propertyValues = new Map<string, string>();
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.addEventListener("change", this.changeListener as EventListener);
-    this.style.display = "unset";
-  }
-
-  override attributeChangedCallback(
-    attr: string,
-    previousValue: string | null,
-    newValue: string | null,
-  ) {
-    super.attributeChangedCallback(attr, previousValue, newValue);
-    this.applyAttributes();
-  }
-
-  applyAttributes() {
-    this.protvistaElements.forEach((element: HTMLElement) => {
-      this["reflected-attributes"]?.forEach((value, type) => {
-        if (value === false || value === null || value === undefined) {
-          element.removeAttribute(type);
-        } else {
-          element.setAttribute(type, typeof value === "boolean" ? "" : value);
-        }
-      });
-      // Default properties
-      if (this.length) {
-        element.setAttribute("length", `${this.length}`);
-      }
-      if (this["display-end"]) {
-        element.setAttribute("display-end", `${this["display-end"]}`);
-      }
-      if (this["display-start"]) {
-        element.setAttribute("display-start", `${this["display-start"]}`);
-      }
-      if (this.highlight) {
-        element.setAttribute("highlight", this.highlight);
-      }
-    });
-  }
-
-  register(element: NightingaleElement) {
-    this.protvistaElements.add(element);
-    this.applyAttributes();
-  }
-
-  unregister(element: NightingaleElement) {
-    this.protvistaElements.delete(element);
-  }
-
-  applyProperties(forElementId: string) {
-    if (forElementId) {
-      const element = this.querySelector(`#${forElementId}`) as HTMLElement;
-      if (!element) {
-        return;
-      }
-      this.propertyValues.forEach((value, type) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (element as any)[type] = value;
-      });
-    } else {
-      this.protvistaElements.forEach((element: HTMLElement) => {
-        if (!element) {
-          return;
-        }
-        this.propertyValues.forEach((value, type) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (element as any)[type] = value;
-        });
-      });
+    connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener("change", this.changeListener as EventListener);
+        document.addEventListener("click", this.handleDocumentClick.bind(this));
+        this.style.display = "unset";
     }
-  }
 
-  isRegisteredAttribute(attributeName: string) {
-    if (!this["reflected-attributes"]) {
-      return false;
-    }
-    return (
-      [...this["reflected-attributes"].keys()].includes(attributeName) ||
-      NightingaleManager.observedAttributes.includes(attributeName)
-    );
-  }
-
-  changeListener(e: CustomEvent) {
-    if (!e.detail) {
-      return;
-    }
-    switch (e.detail.handler) {
-      case "property":
-        this.propertyValues.set(e.detail.type, e.detail.value);
-        this.applyProperties(e.detail.for);
-        break;
-      default:
-        if (this.isRegisteredAttribute(e.detail.type)) {
-          this["reflected-attributes"]?.set(e.detail.type, e.detail.value);
-        }
-        Object.keys(e.detail).forEach((key) => {
-          if (this.isRegisteredAttribute(key)) {
-            this["reflected-attributes"]?.set(key, e.detail[key]);
-          }
-        });
+    override attributeChangedCallback(attr: string, previousValue: string | null, newValue: string | null) {
+        super.attributeChangedCallback(attr, previousValue, newValue);
         this.applyAttributes();
     }
-  }
+
+    applyAttributes() {
+        this.protvistaElements.forEach((element: HTMLElement) => {
+            this["reflected-attributes"]?.forEach((value, type) => {
+                if (value === false || value === null || value === undefined) {
+                    element.removeAttribute(type);
+                } else {
+                    element.setAttribute(type, typeof value === "boolean" ? "" : value);
+                }
+            });
+            // Default properties
+            if (this.length) {
+                element.setAttribute("length", `${this.length}`);
+            }
+            if (this["display-end"]) {
+                element.setAttribute("display-end", `${this["display-end"]}`);
+            }
+            if (this["display-start"]) {
+                element.setAttribute("display-start", `${this["display-start"]}`);
+            }
+            if (this.highlight) {
+                element.setAttribute("highlight", this.highlight);
+            }
+        });
+    }
+
+    register(element: NightingaleElement) {
+        this.protvistaElements.add(element);
+        this.applyAttributes();
+    }
+
+    unregister(element: NightingaleElement) {
+        this.protvistaElements.delete(element);
+    }
+
+    applyProperties(forElementId: string) {
+        if (forElementId) {
+            const element = this.querySelector(`#${forElementId}`) as HTMLElement;
+            if (!element) {
+                return;
+            }
+            this.propertyValues.forEach((value, type) => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (element as any)[type] = value;
+            });
+        } else {
+            this.protvistaElements.forEach((element: HTMLElement) => {
+                if (!element) {
+                    return;
+                }
+                this.propertyValues.forEach((value, type) => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    (element as any)[type] = value;
+                });
+            });
+        }
+    }
+
+    isRegisteredAttribute(attributeName: string) {
+        if (!this["reflected-attributes"]) {
+            return false;
+        }
+        return [...this["reflected-attributes"].keys()].includes(attributeName) || NightingaleManager.observedAttributes.includes(attributeName);
+    }
+
+    // This function is the click listener for the entire document - responsible for closing tooltips and de-highlighting
+    handleDocumentClick(event: MouseEvent) {
+        const isClickInsideFeatureOrTooltip = event.composedPath().some((element) => {
+            const el = element as HTMLElement;
+            return el.classList?.contains("outer-rectangle") || (el.nodeType === Node.ELEMENT_NODE && (el as HTMLElement).closest("nightingale-tooltip"));
+        });
+
+        // If click occurs outside of tooltip or feature track, remove and de-highlight
+        if (!isClickInsideFeatureOrTooltip) {
+            const tooltip = this.querySelector("nightingale-tooltip");
+            if (tooltip) {
+                const tooltipElement = tooltip.shadowRoot?.querySelector(".tooltip");
+                if (tooltipElement && !tooltipElement.contains(event.target as Node)) {
+                    (tooltip as any).hideTooltip();
+                    this.highlight = "null";
+                    this.applyAttributes();
+                }
+            }
+        }
+    }
+
+    handleTrackClick(event: CustomEvent) {
+        if (event.detail?.eventType === "click") {
+            event.stopPropagation(); // Prevent event from bubbling up to document
+            const tooltip = this.querySelector("nightingale-tooltip");
+
+            if (!tooltip) {
+                console.error("Tooltip element not found in the DOM.");
+                return;
+            }
+
+            const [x, y] = event.detail.coords;
+
+            // Ensure `showTooltip` exists on the element
+            if (typeof (tooltip as any).showTooltip === "function") {
+                let feature = event.detail.feature;
+                if (feature) {
+                    (tooltip as any).showTooltip(
+                        x,
+                        y,
+                        {
+                            description: feature.description || "Random description",
+                            evidence: feature.evidence || "Random evidence",
+                        },
+                        feature.accession
+                    );
+
+                    this.highlight = event.detail.highlight;
+                }
+            } else {
+                console.error("Tooltip element does not have a showTooltip method.");
+            }
+        }
+    }
+
+    changeListener(e: CustomEvent) {
+        if (!e.detail) {
+            return;
+        }
+        switch (e.detail.handler) {
+            case "property":
+                this.propertyValues.set(e.detail.type, e.detail.value);
+                this.applyProperties(e.detail.for);
+                break;
+            default:
+                if (this.isRegisteredAttribute(e.detail.type)) {
+                    this["reflected-attributes"]?.set(e.detail.type, e.detail.value);
+                }
+                Object.keys(e.detail).forEach((key) => {
+                    if (this.isRegisteredAttribute(key)) {
+                        this["reflected-attributes"]?.set(key, e.detail[key]);
+                    }
+                });
+                this.handleTrackClick(e);
+                this.applyAttributes();
+        }
+    }
 }
 
 export default NightingaleManager;

--- a/packages/nightingale-new-core/src/utils/bindEvents.ts
+++ b/packages/nightingale-new-core/src/utils/bindEvents.ts
@@ -23,7 +23,7 @@ type SequenceBaseData = {
 
 type detailInterface = {
   eventType: EventType;
-  // coords: null | [number, number];
+  coords: null | [number, number];
   feature?: FeatureData | SequenceBaseData | null;
   target?: HTMLElement;
   highlight?: string;
@@ -51,6 +51,7 @@ export function createEvent(
     eventType: type,
     // TODO: add coordinates
     // coords: WithNightingaleEvents._getClickCoords(),
+    coords: event ? [(event as MouseEvent).clientX, (event as MouseEvent).clientY]: null,
     feature,
     target,
     parentEvent: event,
@@ -83,42 +84,36 @@ export default function bindEvents<T extends BaseType>(
   element: NightingaleBaseElement,
 ) {
   feature
-    .on("mouseover", function (event: Event, datum: unknown) {
-      element.dispatchEvent(
-        createEvent(
-          "mouseover",
-          datum as FeatureData | SequenceBaseData,
-          element.getAttribute(HIGHLIGHT_EVENT) === "onmouseover",
-          false,
-          (datum as FeatureData).start ?? (datum as SequenceBaseData).position,
-          (datum as FeatureData).end ?? (datum as SequenceBaseData).position,
-          this as unknown as HTMLElement,
-          event,
-        ),
-      );
-    })
-    .on("mouseout", () => {
-      element.dispatchEvent(
-        createEvent(
-          "mouseout",
-          null,
-          element.getAttribute(HIGHLIGHT_EVENT) === "onmouseover",
-        ),
-      );
-    })
-    .on("click", function (event: Event, datum: unknown) {
-      element.dispatchEvent(
-        createEvent(
-          "click",
-          datum as FeatureData | SequenceBaseData,
-          element.getAttribute(HIGHLIGHT_EVENT) === "onclick",
-          true,
-          (datum as FeatureData).start ?? (datum as SequenceBaseData).position,
-          (datum as FeatureData).end ?? (datum as SequenceBaseData).position,
-          this as unknown as HTMLElement,
-          event,
-          element as NightingaleBaseElement & WithHighlightInterface,
-        ),
-      );
-    });
+      .on("mouseover", function (event: MouseEvent, datum: unknown) {
+          element.dispatchEvent(
+              createEvent(
+                  "mouseover",
+                  datum as FeatureData | SequenceBaseData,
+                  element.getAttribute(HIGHLIGHT_EVENT) === "onmouseover",
+                  false,
+                  (datum as FeatureData).start ?? (datum as SequenceBaseData).position,
+                  (datum as FeatureData).end ?? (datum as SequenceBaseData).position,
+                  this as unknown as HTMLElement,
+                  event
+              )
+          );
+      })
+      .on("mouseout", () => {
+          element.dispatchEvent(createEvent("mouseout", null, element.getAttribute(HIGHLIGHT_EVENT) === "onmouseover"));
+      })
+      .on("click", function (event: MouseEvent, datum: unknown) {
+          element.dispatchEvent(
+              createEvent(
+                  "click",
+                  datum as FeatureData | SequenceBaseData,
+                  element.getAttribute(HIGHLIGHT_EVENT) === "onclick",
+                  true,
+                  (datum as FeatureData).start ?? (datum as SequenceBaseData).position,
+                  (datum as FeatureData).end ?? (datum as SequenceBaseData).position,
+                  this as unknown as HTMLElement,
+                  event,
+                  element as NightingaleBaseElement & WithHighlightInterface
+              )
+          );
+      });
 }

--- a/packages/nightingale-tooltip/README.md
+++ b/packages/nightingale-tooltip/README.md
@@ -1,0 +1,39 @@
+# nightingale-tooltip
+
+!Not published
+
+Tooltip component that is triggered when user selects a track. Tooltip shows feature accession as `title` and contents include `description` and `evidence`.
+
+Does not affect sequence highlighting by `nightingale-track`
+
+## Usage
+
+```html
+<nightingale-manager reflected-attributes="attr1 attr2">
+  <other-nightingale-component attr1="X" attr2="Y" />
+  <nightingale-tooltip></nightingale-tooltip>
+</nightingale-manager>
+```
+
+## API Reference
+
+### Properties
+
+#### `showTooltip(x: number, y: number, content: { description: string; evidence: string }, accession: string)`:
+
+x and y: coordinates of MouseEvent (click)
+Hides any current open tooltip, and opens a new one with the given parameters. Sets visible flag on `nightingale-tooltip` component to true.
+
+#### `unregister(element: NightingaleElement)`:
+
+Sets visible flag on `nightingale-tooltip` component to false.
+
+### Property
+
+#### `title: string | ""`
+
+#### `visible: boolean | false`
+
+#### `tooltipContent: { description: string, evidence: string } | { description: "", evidence: "" }`
+
+#### `container: string | "html"`

--- a/packages/nightingale-tooltip/package.json
+++ b/packages/nightingale-tooltip/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@nightingale-elements/nightingale-tooltip",
+  "version": "5.0.0",
+  "description": "Tooltip component for the Nightingale tool",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "type": "module",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rollup --config ../../rollup.config.mjs",
+    "test": "../../node_modules/.bin/jest --config ../../jest.config.js ./tests/*"
+  },
+  "license": "ISC",
+  "keywords": [
+    "nightingale",
+    "webcomponents",
+    "customelements"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ebi-webcomponents/nightingale.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ebi-webcomponents/nightingale/issues"
+  },
+  "homepage": "https://ebi-webcomponents.github.io/nightingale/",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@nightingale-elements/nightingale-new-core": "^5.0.0",
+    "d3": "7.9.0"
+  }
+}

--- a/packages/nightingale-tooltip/src/index.ts
+++ b/packages/nightingale-tooltip/src/index.ts
@@ -1,0 +1,2 @@
+import NightingaleTooltip from "./nightingale-tooltip";
+export default NightingaleTooltip;

--- a/packages/nightingale-tooltip/src/nightingale-tooltip.ts
+++ b/packages/nightingale-tooltip/src/nightingale-tooltip.ts
@@ -1,0 +1,107 @@
+import { html, css, LitElement } from "lit";
+import { property, customElement } from "lit/decorators.js";
+
+@customElement("nightingale-tooltip")
+class NightingaleTooltip extends LitElement {
+    @property({ type: String, reflect: true })
+    title: string = "";
+
+    @property({ type: Boolean, reflect: true })
+    visible: boolean = false;
+
+    @property({ type: Object })
+    tooltipContent: { description: string; evidence: string } = { description: "", evidence: "" };
+
+    @property({ type: String, reflect: true })
+    container: string = "html";
+
+    static styles = css`
+        :host {
+            --z-index: 50000;
+            --title-color: black;
+            --text-color: white;
+            --body-color: #616161;
+            --triangle-width: 16px;
+            --triangle-height: 10px;
+            --triangle-margin: 10px;
+            --vertical-distance: 5px;
+        }
+
+        .tooltip {
+            font-family: Roboto, Arial, sans-serif;
+            font-size: 0.9rem;
+            display: none; /* Hide initially */
+            position: absolute;
+            min-width: 220px;
+            max-width: 50vw;
+            z-index: var(--z-index);
+            color: var(--text-color);
+            background: var(--body-color);
+            padding: 10px;
+            border-radius: 5px;
+            pointer-events: none;
+            transition: opacity 0.3s;
+            white-space: normal; /* Ensure text wraps */
+            word-wrap: break-word; /* Ensure long words break */
+            line-height: 1.5; /* Add line height for better readability */
+        }
+
+        .tooltip.visible {
+            display: block; /* Show when visible */
+            opacity: 0.9;
+            pointer-events: auto;
+        }
+
+        h1 {
+            margin: 0;
+            background-color: var(--title-color);
+            line-height: 2em;
+            padding: 0 1ch;
+        }
+
+        .tooltip-body {
+            padding: 1em;
+            background: var(--body-color);
+            font-weight: normal;
+            overflow-y: auto;
+            max-height: 40vh;
+        }
+
+        p {
+            margin: 0; /* Remove default margin to avoid extra space */
+            padding: 0; /* Remove default padding to avoid extra space */
+        }
+    `;
+
+    render() {
+        return html`
+            <section class="tooltip ${this.visible ? "visible" : ""}">
+                <h1>${this.title}</h1>
+                <div class="tooltip-body">
+                    <p>Description: ${this.tooltipContent.description}</p>
+                    <p>Evidence: ${this.tooltipContent.evidence}</p>
+                </div>
+            </section>
+        `;
+    }
+
+    showTooltip(x: number, y: number, content: { description: string; evidence: string }, accession: string) {
+        // Hide tooltip before displaying new one
+        this.hideTooltip();
+
+        const tooltip = this.shadowRoot?.querySelector(".tooltip") as HTMLElement;
+        if (tooltip) {
+            tooltip.style.left = `${x}px`;
+            tooltip.style.top = `${y}px`;
+            this.tooltipContent = content;
+            this.title = accession;
+            this.visible = true;
+        }
+    }
+
+    hideTooltip() {
+        this.visible = false;
+    }
+}
+
+export default NightingaleTooltip;

--- a/packages/nightingale-tooltip/tsconfig.json
+++ b/packages/nightingale-tooltip/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["./src"]
+}

--- a/packages/nightingale-track/src/nightingale-track.ts
+++ b/packages/nightingale-track/src/nightingale-track.ts
@@ -35,7 +35,8 @@ export type Feature = {
   color?: string;
   fill?: string;
   shape?: Shapes;
-  tooltipContent?: string;
+  description?: string;
+  evidence?: string;
   type?: string;
   locations?: Array<FeatureLocation>;
   feature?: Feature;


### PR DESCRIPTION
I am using this nightingale library for antibody sequence visualisation and it was missing a tooltip component. I have implemented this component, feel free to use it if deemed useful.

- Edited Feature type to include "description" and "evidence" instead of "tooltipContent".
- Main CSS styling for tooltip is in nightingale-tooltip
- Implemented a handleTrackClick in nightingale-manager that is called by the existing "change" event listener when a track is clicked
- Implemented new document event listener to handle closing of tooltip and de-highlighting when user clicks elsewhere on the screen

Thank you.