### PR TITLE
nightingale-track-canvas: implement missing shapes

### DIFF
--- a/packages/nightingale-track-canvas/src/utils/draw-shapes.ts
+++ b/packages/nightingale-track-canvas/src/utils/draw-shapes.ts
@@ -333,6 +333,46 @@ const RangeDrawers: Partial<Record<Shapes, RangeDrawer>> = {
     ctx.fill();
     ctx.stroke();
   },
+
+  rightEndedTag(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number, xPadding: number): void {
+    const head = Math.min(0.75 * height, 1.00 * width);
+    ctx.beginPath();
+    ctx.moveTo(x, y + height);
+    ctx.lineTo(x + width - head, y + height);
+    ctx.lineTo(x + width, y + 0.5 * height);
+    ctx.lineTo(x + width - head, y);
+    ctx.lineTo(x, y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+  },
+
+  leftEndedTag(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number, xPadding: number): void {
+    const head = Math.min(0.75 * height, 1.00 * width);
+    ctx.beginPath();
+    ctx.moveTo(x + width, y + height);
+    ctx.lineTo(x + head, y + height);
+    ctx.lineTo(x, y + 0.5 * height);
+    ctx.lineTo(x + head, y);
+    ctx.lineTo(x + width, y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+  },
+
+  doubleEndedTag(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number, xPadding: number): void {
+    const head = Math.min(0.75 * height, 0.5 * width);
+    ctx.beginPath();
+    ctx.moveTo(x + head, y + height);
+    ctx.lineTo(x + width - head, y + height);
+    ctx.lineTo(x + width, y + 0.5 * height);
+    ctx.lineTo(x + width - head, y);
+    ctx.lineTo(x + head, y);
+    ctx.lineTo(x, y + 0.5 * height);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+  },
 };
 
 // Future-proofing for fixing typos (discontinUOS -> discontinUOUS)

--- a/stories/18.NightingaleTrackCanvas/NightingaleTrackCanvas.stories.ts
+++ b/stories/18.NightingaleTrackCanvas/NightingaleTrackCanvas.stories.ts
@@ -34,6 +34,7 @@ const Shapes = [
   "rectangle", "roundRectangle", "line", "bridge",
   "discontinuosEnd", "discontinuos", "discontinuosStart",
   "helix", "strand",
+  "rightEndedTag", "leftEndedTag", "doubleEndedTag",
   "circle", "triangle", "diamond", "pentagon", "hexagon",
   "chevron", "catFace", "arrow", "wave", "doubleBar",
 ];


### PR DESCRIPTION
Implement missing shapes in nightingale-track-canvas, those being "rightEndedTag", "leftEndedTag", and "doubleEndedTag".

I have also added these shapes in the "All shapes" storybook demo. Here's how they look (SVG above, Canvas below):

![image](https://github.com/user-attachments/assets/ef1d56ba-4165-435c-935a-1967680d73ce)
