### PR TITLE
Heatmap scale fix

### DIFF
--- a/packages/nightingale-sequence-heatmap/README.md
+++ b/packages/nightingale-sequence-heatmap/README.md
@@ -86,8 +86,10 @@ customElements.whenDefined("nightingale-sequence-heatmap").then( async() => {
   heatmapElement.setHeatmapData(xDomain, yDomain, data);
 
   const colorScale = d3.scaleLinear(
-    [0, 1], // score value domain
-    ["#ffffff", "#00441b"], // color range to map values
+    // Score value domain:
+    [0, 0.1132, 0.2264, 0.3395, 0.4527, 0.5895, 0.7264, 0.8632, 1],
+    // Corresponding colors:
+    ["#2166ac", "#4290bf", "#8cbcd4", "#c3d6e0", "#e2e2e2", "#edcdba", "#e99e7c", "#d15e4b", "#b2182b"] 
   );
 
   await heatmapElement.updateComplete.then(() => {

--- a/packages/nightingale-sequence-heatmap/package.json
+++ b/packages/nightingale-sequence-heatmap/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@nightingale-elements/nightingale-new-core": "^5.4.0",
     "d3": "7.9.0",
-    "heatmap-component": "1.1.0"
+    "heatmap-component": "1.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nightingale-sequence-heatmap/src/heatmap-component.css.ts
+++ b/packages/nightingale-sequence-heatmap/src/heatmap-component.css.ts
@@ -1,4 +1,18 @@
 const heatmapStyles = `
+/**
+ * heatmap-component
+ * @version 1.2.0
+ * @link https://github.com/PDBeurope/heatmap-component
+ * @license Apache-2.0
+ */
+
+:root {
+    /** Position of bottom-left corner of tooltip box relative to the mouse position */
+    --tooltip-offset-x: 5px;
+    /** Position of bottom-left corner of tooltip box relative to the mouse position */
+    --tooltip-offset-y: 8px;
+}
+
 .heatmap-main-div {
     font-family: sans-serif;
 }
@@ -7,6 +21,32 @@ const heatmapStyles = `
     /* Set background-color here to change the background of the heatmap */
     background-color: none;
 }
+
+.heatmap-svg[pointing-data] {
+    /** Show "pointer" cursor when hovering over a cell with data */
+    cursor: pointer;
+}
+
+
+/* Marker extension */
+
+.heatmap-marker {
+    stroke: black;
+    stroke-width: 4;
+    fill: none;
+    pointer-events: none;
+}
+
+.heatmap-marker-x,
+.heatmap-marker-y {
+    stroke: black;
+    stroke-width: 2;
+    fill: none;
+    pointer-events: none;
+}
+
+
+/* Tooltip extension */
 
 .heatmap-tooltip-box,
 .heatmap-pinned-tooltip-box {
@@ -26,7 +66,6 @@ const heatmapStyles = `
     box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.75);
     pointer-events: initial;
     width: max-content;
-    line-height: 1;
 }
 
 .heatmap-pinned-tooltip-close {
@@ -63,6 +102,9 @@ const heatmapStyles = `
     fill: black;
 }
 
+
+/* Overlay (Zoom extension) */
+
 .heatmap-overlay {
     position: absolute;
     width: 100%;
@@ -96,16 +138,21 @@ const heatmapStyles = `
     box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.75);
 }
 
-.heatmap-marker {
-    stroke: black;
-    stroke-width: 4;
-    fill: none;
+
+/* Brush extension */
+
+.heatmap-brush-close {
+    cursor: pointer;
 }
 
-.heatmap-marker-x,
-.heatmap-marker-y {
+.heatmap-brush-close .cross {
+    fill: black;
     stroke: black;
-    stroke-width: 2;
-    fill: none;
-}`;
+}
+
+.heatmap-brush-close .circle {
+    fill: white;
+    stroke: white;
+}
+`;
 export default heatmapStyles;

--- a/packages/nightingale-sequence-heatmap/src/nightingale-sequence-heatmap.ts
+++ b/packages/nightingale-sequence-heatmap/src/nightingale-sequence-heatmap.ts
@@ -150,23 +150,27 @@ class NightingaleSequenceHeatmap extends withManager(
     if (this.heatmapData) {
       // style tag here may seem strange but see: https://lit.dev/docs/v1/lit-html/styling-templates/#rendering-in-shadow-dom
       return html` <style>
-          #${this["heatmap-id"]} {
-            /** Position of bottom-left corner of tooltip box relative to the mouse position */
-            --tooltip-offset-x: 5px;
-            /** Position of bottom-left corner of tooltip box relative to the mouse position */
-            --tooltip-offset-y: 8px;
+          /* Default heatmap-component CSS */
+          ${heatmapStyleSheet}
+
+          /* Nightingale CSS */
+          .heatmap-tooltip-content,
+          .heatmap-pinned-tooltip-content {
+            line-height: 1;
           }
           .heatmap-marker-x {
-            fill: ${colorString} !important;
-            fill-opacity: ${fillValue} !important;
-            stroke-width: ${highlightWidth} !important;
+            fill: ${colorString};
+            fill-opacity: ${fillValue};
+            stroke-width: ${highlightWidth};
           }
           .heatmap-marker-y {
-            fill: ${colorString} !important;
-            fill-opacity: ${fillValue} !important;
-            stroke-width: ${highlightWidth} !important;
+            fill: ${colorString};
+            fill-opacity: ${fillValue};
+            stroke-width: ${highlightWidth};
           }
-          ${heatmapStyleSheet}
+          .heatmap-svg[pointing-data] {
+            cursor: default;
+          }
         </style>
 
         <div id="container">

--- a/packages/nightingale-sequence-heatmap/src/nightingale-sequence-heatmap.ts
+++ b/packages/nightingale-sequence-heatmap/src/nightingale-sequence-heatmap.ts
@@ -1,14 +1,3 @@
-import { PropertyValueMap, html } from "lit";
-import { property } from "lit/decorators.js";
-import { styleMap } from "lit-html/directives/style-map.js";
-import { scaleSequential, Selection as d3Selection, select, EnterElement } from "d3";
-import { Heatmap } from "heatmap-component";
-import { Class as HeatmapClassNames } from "heatmap-component/lib/heatmap-component/class-names";
-import {
-  Box,
-  scaleDistance,
-} from "heatmap-component/lib/heatmap-component/scales";
-
 import NightingaleElement, {
   customElementOnce,
   withDimensions,
@@ -19,11 +8,12 @@ import NightingaleElement, {
   withResizable,
   withZoom,
 } from "@nightingale-elements/nightingale-new-core";
-import { SegmentType } from "@nightingale-elements/nightingale-new-core/dist/utils/Region";
-
+import { scaleSequential, select, Selection } from "d3";
+import { Heatmap } from "heatmap-component";
+import { html, PropertyValueMap } from "lit";
+import { styleMap } from "lit-html/directives/style-map.js";
+import { property } from "lit/decorators.js";
 import heatmapStyleSheet from "./heatmap-component.css";
-import { State } from "heatmap-component/lib/heatmap-component/state";
-import { MarkerExtensionParams } from "heatmap-component/lib/heatmap-component/extensions/marker";
 
 
 const ALPHAMISSENSE_BLUE = "#3d5493";
@@ -36,33 +26,6 @@ interface HeatmapData {
   // unknown so we are flexible to user data formats
   [key: string]: unknown;
 }
-
-const hexComponentToNumber = (hexComp: string): number => {
-  return parseInt(hexComp, 16);
-};
-
-const formatDataItem = (item: unknown): string => {
-  if (typeof item === "number") return item.toFixed(3);
-  else return JSON.stringify(item);
-};
-
-const hexToRgb = (
-  hex: string
-): { r: number; g: number; b: number; a?: number } | null => {
-  let result = null;
-  if (hex.length === 7)
-    result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  if (hex.length === 9)
-    result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  return result
-    ? {
-      r: hexComponentToNumber(result[1]),
-      g: hexComponentToNumber(result[2]),
-      b: hexComponentToNumber(result[3]),
-      a: hex.length === 9 ? hexComponentToNumber(result[4]) : undefined,
-    }
-    : null;
-};
 
 
 @customElementOnce("nightingale-sequence-heatmap")
@@ -91,18 +54,36 @@ class NightingaleSequenceHeatmap extends withManager(
   heatmapDomainY?: string[];
   heatmapData?: HeatmapData[];
   heatmapInstance?: Heatmap<number, string, HeatmapData>;
+  protected highlighted?: Selection<SVGGElement, unknown, HTMLElement | SVGElement | null, unknown>;
 
   /**
    * Nightingale lifecycle function to update highlight (see withHighlight)
    * has to be manually triggered from render (zoomRefreshed and updated in this case)
    */
   protected updateHighlight() {
-    this.triggerHeatmapHighlight();
+    if (!this.highlighted) return;
+
+    const highlights = this.highlighted
+      .selectAll<SVGRectElement, { start: number, end: number }[]>("rect")
+      .data(this.highlightedRegion.segments);
+
+    highlights
+      .enter()
+      .append("rect")
+      .style("pointer-events", "none")
+      .merge(highlights)
+      .attr("fill", this["highlight-color"])
+      .attr("y", 0)
+      .attr("height", this.height)
+      .attr("x", d => this.getXFromSeqPosition(d.start) - this["margin-left"]) // subtracting margin-left because highlights are rendered in the heatmap-component's SVG, which does not cover the margins
+      .attr("width", d => Math.max(0, this.getSingleBaseWidth() * (d.end - d.start + 1)));
+
+    highlights.exit().remove();
   }
 
   override attributeChangedCallback(name: string, _old: string | null, value: string | null): void {
     super.attributeChangedCallback(name, _old, value);
-    if (name === "highlight") {
+    if (name === "highlight" || name === "highlight-color") {
       this.updateHighlight();
     }
     if (name === "display-start" || name === "display-end") {
@@ -133,20 +114,6 @@ class NightingaleSequenceHeatmap extends withManager(
       textAlign: "center",
     };
 
-    // required to allow hex with alpha channel to work with fill property
-    let colorString = this["highlight-color"];
-    let fillValue = 0.9;
-
-    const highlightWidth = this["hm-highlight-width"];
-
-    const rgb = hexToRgb(this["highlight-color"]);
-    if (rgb) {
-      colorString = `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
-      fillValue = rgb.a
-        ? parseFloat(formatDataItem(0.9 * (rgb.a / 256.0)))
-        : 0.9;
-    }
-
     if (this.heatmapData) {
       // style tag here may seem strange but see: https://lit.dev/docs/v1/lit-html/styling-templates/#rendering-in-shadow-dom
       return html` <style>
@@ -158,15 +125,9 @@ class NightingaleSequenceHeatmap extends withManager(
           .heatmap-pinned-tooltip-content {
             line-height: 1;
           }
-          .heatmap-marker-x {
-            fill: ${colorString};
-            fill-opacity: ${fillValue};
-            stroke-width: ${highlightWidth};
-          }
+          .heatmap-marker-x,
           .heatmap-marker-y {
-            fill: ${colorString};
-            fill-opacity: ${fillValue};
-            stroke-width: ${highlightWidth};
+            display: none;
           }
           .heatmap-svg[pointing-data] {
             cursor: default;
@@ -177,10 +138,7 @@ class NightingaleSequenceHeatmap extends withManager(
           <div id="${this["heatmap-id"]}" style=${styleMap(heatmapStyles)} />
         </div>`;
     } else {
-      return html` <div
-        id="${this["heatmap-id"]}_loading"
-        style=${styleMap(loadingStyles)}
-      >
+      return html` <div id="${this["heatmap-id"]}_loading" style=${styleMap(loadingStyles)}>
         ${loaderSvg}
       </div>`;
     }
@@ -195,9 +153,11 @@ class NightingaleSequenceHeatmap extends withManager(
   ): void {
     super.updated(_changedProperties);
     if (this.heatmapData && !this.heatmapInstance) {
-      this.svg = select(this).select("div#container"); // necessary for WithZoom mixin to work
       this.renderHeatmap();
+      this.svg = select(this).select("div#container"); // necessary for WithZoom mixin to work
+      this.highlighted = select(this).select("svg.heatmap-svg").append("g").classed("highlighted", true);
       this.bindHeatmapEvents();
+      this.updateHighlight();
     }
   }
 
@@ -273,7 +233,7 @@ class NightingaleSequenceHeatmap extends withManager(
       const returnHTML = `
         <b>You are at</b> <br />
         x,y: <b>${d.xValue},${d.yValue}</b><br />
-        score: <b>${formatDataItem(d.score)}</b>`;
+        score: <b>${d.score.toFixed(3)}</b>`;
       return returnHTML;
     });
     hm.setVisualParams({ xGapPixels: 0, yGapPixels: 0 });
@@ -282,15 +242,7 @@ class NightingaleSequenceHeatmap extends withManager(
     this.heatmapInstance.render(this["heatmap-id"]!);
     // first zoom trigger if it exists
     this.heatmapInstance.events.render.subscribe(() => {
-      // console.log('render1', this.heatmapInstance?.events.resize.value)
       this.requestUpdate();
-      // console.log('render2', this.heatmapInstance?.events.resize.value)
-      // setTimeout(() => {
-      //   // console.log('render3', this.heatmapInstance?.events.resize.value);
-      //   const state = (this.heatmapInstance as any)?.state;
-      //   console.log('scales: canvas', ...state.scales.canvasToWorld.x.domain(), 'world', ...state.scales.canvasToWorld.x.range(),)
-      //   // this.heatmapInstance?.events.resize.next(this.heatmapInstance.events.resize.value);
-      // }, 2000)
     });
   }
 
@@ -315,8 +267,6 @@ class NightingaleSequenceHeatmap extends withManager(
   private dispatchHighlight(seqPosition: number | undefined) {
     // Data to send to nightingale can be null if pointer is outside boundaries
     const highlight = seqPosition !== undefined ? `${seqPosition}:${seqPosition}` : null;
-    // console.log('heatmap dispatchHighlight', seqPosition)
-    // console.log('svg', this.svg)
     this.dispatchEvent(
       new CustomEvent("change", {
         detail: { type: "highlight", value: highlight },
@@ -338,42 +288,6 @@ class NightingaleSequenceHeatmap extends withManager(
         xMax: toEnd,
       });
     }
-  }
-
-  /**
-   * Function to trigger Heatmap highlighting from Nightingale
-   */
-  triggerHeatmapHighlight() {
-    const heatmapInstanceMarker = this.heatmapInstance?.extensions.marker;
-    if (!heatmapInstanceMarker) return;
-
-    const params = heatmapInstanceMarker?.getParams();
-    const heatmapState = (this.heatmapInstance as any).state as State<unknown, unknown, unknown>;
-
-    // support for multiple segments
-    const className = HeatmapClassNames.MarkerY;
-    heatmapState.dom?.svg
-      .selectAll<SVGRectElement, SegmentType>("." + className)
-      .data(this.highlightedRegion.segments)
-      .join(
-        (enter: d3Selection<EnterElement, SegmentType, any, any>) =>
-          enter
-            .append("rect")
-            .attr("class", className)
-            .attr("rx", params.markerCornerRadius)
-            .attr("ry", params.markerCornerRadius)
-            .attr("x", d => heatmapState.scales.worldToSvg.x(d.start - 1))
-            .attr("y", heatmapState.boxes.svg.ymin)
-            .attr("width", d => scaleDistance(heatmapState.scales.worldToSvg.x, Math.max(d.end - d.start + 1, 1)))
-            .attr("height", Box.height(heatmapState.boxes.svg)),
-        // update is basically same as enter
-        (update: d3Selection<SVGRectElement, SegmentType, any, any>) =>
-          update
-            .attr("x", d => heatmapState.scales.worldToSvg.x(d.start - 1))
-            .attr("width", d => scaleDistance(heatmapState.scales.worldToSvg.x, Math.max(d.end - d.start + 1, 1))),
-        (exit: d3Selection<SVGRectElement, SegmentType, any, any>) =>
-          exit.remove(),
-      );
   }
 }
 export default NightingaleSequenceHeatmap;

--- a/packages/nightingale-sequence-heatmap/src/nightingale-sequence-heatmap.ts
+++ b/packages/nightingale-sequence-heatmap/src/nightingale-sequence-heatmap.ts
@@ -8,16 +8,16 @@ import NightingaleElement, {
   withResizable,
   withZoom,
 } from "@nightingale-elements/nightingale-new-core";
-import { scaleSequential, select, Selection } from "d3";
-import { Heatmap } from "heatmap-component";
+import { max, min, select, Selection } from "d3";
+import { ColorScale, Heatmap } from "heatmap-component";
 import { html, PropertyValueMap } from "lit";
 import { styleMap } from "lit-html/directives/style-map.js";
 import { property } from "lit/decorators.js";
 import heatmapStyleSheet from "./heatmap-component.css";
 
 
-const ALPHAMISSENSE_BLUE = "#3d5493";
-const ALPHAMISSENSE_RED = "#9a131a";
+/** Default coloring scheme (YlGn scheme from ColorBrewer) */
+const DEFAULT_COLORS = "#ffffe5 #f7fcb9 #d9f0a3 #addd8e #78c679 #41ab5d #238443 #006837 #004529".split(" ");
 
 interface HeatmapData {
   xValue: number;
@@ -220,13 +220,11 @@ class NightingaleSequenceHeatmap extends withManager(
       y: d => d.yValue ?? "none",
     });
 
-    const dataMin = Math.min(...this.heatmapData!.map((datum) => datum.score));
-    const dataMax = Math.max(...this.heatmapData!.map((datum) => datum.score));
+    const dataMin = min(this.heatmapData?.map(d => d.score) ?? []) ?? 0;
+    const dataMax = max(this.heatmapData?.map(d => d.score) ?? []) ?? 1;
 
-    const colorScale = scaleSequential(
-      [dataMin, dataMax],
-      [ALPHAMISSENSE_BLUE, ALPHAMISSENSE_RED]
-    );
+    const scaleValues = DEFAULT_COLORS.map((_, i) => dataMin + (dataMax - dataMin) * i / (DEFAULT_COLORS.length - 1));
+    const colorScale = ColorScale.continuous(scaleValues, DEFAULT_COLORS);
     hm.setColor((d) => colorScale(d.score));
 
     hm.setTooltip((d, _x, _y, _xIndex, _yIndex) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9517,10 +9517,10 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-heatmap-component@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/heatmap-component/-/heatmap-component-1.1.0.tgz#34453c7e60900ebf861b520204e1aeaf2484b95e"
-  integrity sha512-RsO30/yEFhl7bfEUJ1Wq4pbUDefbxaoHfkYrCxieL+9PbzOP4vYQ8vFqK3BHTfMyPJ5uLqLEETXpYi8GJrIrJw==
+heatmap-component@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/heatmap-component/-/heatmap-component-1.2.0.tgz#64356b478a997775417cc396131a2cb8ed9e4b8b"
+  integrity sha512-zl2TBhcmof59t/lRaF9kmJLuBE1IVtT3tZyWohfNRXpOEzELKJT1wgnhGu1u+ERvlY7I7JnSo3uo7fUoXKgMsQ==
   dependencies:
     d3 "^7.9.0"
     lodash "^4.17.21"


### PR DESCRIPTION
This PR fixes a bug with NightingaleSequenceHeatmap resizing, which was causing misaligned highlights.
I also changed the default heatmap color scheme to white-yellow-green (YlGn from ColorBrewer).

To apply AlphaMissense coloring, follow the [example](https://github.com/midlik/nightingale/blob/heatmap-scale-fix/packages/nightingale-sequence-heatmap/README.md#setcolord-hotmapdata--) provided in README.md.