### PR TITLE
Tweak comments, benchmarking, types, and code.

### DIFF
--- a/dev/benchmarks/variation-canvas.html
+++ b/dev/benchmarks/variation-canvas.html
@@ -5,14 +5,15 @@
     <title>nightingale-variation-canvas benchmark</title>
     <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
     <script src="../../node_modules/lit/polyfill-support.js"></script>
-    <script
-      type="module"
-      src="../../packages/nightingale-variation/dist/index.js"
-    ></script>
-    <script
-      type="module"
-      src="../../packages/nightingale-variation-canvas/dist/index.js"
-    ></script>
+    <!--
+      Bare imports below are resolved by `web-dev-server.config.mjs` to
+      `packages/*/src/index.ts`, so this page works against the source
+      directly — no `yarn build` step required.
+    -->
+    <script type="module">
+      import "@nightingale-elements/nightingale-variation";
+      import "@nightingale-elements/nightingale-variation-canvas";
+    </script>
     <style>
       body {
         font-family: system-ui, sans-serif;
@@ -60,9 +61,12 @@
       offscreen in <code>#stage</code>.
     </p>
     <p>
-      <strong>Prerequisite:</strong> run <code>yarn build</code> at the repo
-      root before opening this page — the benchmark imports from
-      <code>packages/*/dist/</code>.
+      <strong>How to run:</strong> from the repo root, run
+      <code>yarn benchmark:variation-canvas</code>. That starts the dev server
+      and opens this page in your browser; click <strong>Run benchmark</strong>
+      below to start the sweep. No build step is required — the dev server
+      compiles TypeScript on the fly and serves directly from
+      <code>packages/*/src</code>.
     </p>
     <button id="run">Run benchmark</button>
     <span id="status" style="margin-left: 12px; color: #666;"></span>
@@ -153,6 +157,19 @@
         return el;
       }
 
+      // The canvas component exposes `whenDrawn()` so we can await actual
+      // draw completion. The SVG component has no such hook — it draws
+      // synchronously inside `zoomRefreshed`, so a single RAF after the
+      // setter is enough to cover everything. Either way, this is more
+      // accurate than the previous double-RAF heuristic.
+      async function awaitDraw(el) {
+        if (typeof el.whenDrawn === "function") {
+          await el.whenDrawn();
+        } else {
+          await waitFrame();
+        }
+      }
+
       async function measureInitialLoad(tagName, data) {
         await customElements.whenDefined(tagName);
         const el = setupElement(tagName);
@@ -160,11 +177,8 @@
         await waitFrame();
         const start = performance.now();
         el.data = data;
-        // Yield twice — once for the Refresher sleep(0), once for the raf.
-        await waitFrame();
-        await waitFrame();
-        const elapsed = performance.now() - start;
-        return elapsed;
+        await awaitDraw(el);
+        return performance.now() - start;
       }
 
       async function measureRefresh(tagName, data) {
@@ -172,8 +186,7 @@
         const el = setupElement(tagName);
         await waitFrame();
         el.data = data;
-        await waitFrame();
-        await waitFrame();
+        await awaitDraw(el);
 
         const samples = [];
         let start = 1;
@@ -193,8 +206,7 @@
           const t = performance.now();
           el.setAttribute("display-start", String(start));
           el.setAttribute("display-end", String(end));
-          await waitFrame();
-          await waitFrame();
+          await awaitDraw(el);
           samples.push(performance.now() - t);
         }
         // Median is more stable than mean for these noisy measurements.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "analyze:watch": "cem analyze --litelement --globs \"src/**/*.ts\" --watch",
     "serve": "wds --node-resolve --watch",
     "serve:prod": "MODE=prod yarn serve",
+    "benchmark:variation-canvas": "wds --node-resolve --watch --open /dev/benchmarks/variation-canvas.html",
     "checksize": "rollup -c ; cat my-element.bundled.js | gzip -9 | wc -c ; rm my-element.bundled.js",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/packages/nightingale-variation-canvas/README.md
+++ b/packages/nightingale-variation-canvas/README.md
@@ -30,10 +30,18 @@ This component inherits from `nightingale-variation` and exposes the same attrib
 
 ## Parity gaps
 
-One intentional difference versus `nightingale-variation`:
+Intentional differences versus `nightingale-variation`:
 
 1. **`VariationDatum.internalId` is no longer set as a render side effect.** The SVG render path writes `d.internalId = "var_${wildType}${start}${mutation}"` while drawing. The canvas draw path does not. The field remains on the `VariationDatum` type for consumers that set it themselves.
 
+2. **Click / mouseover dispatch falls back to `start` when `end` is missing.** The SVG version passes `datum.end` straight through to the highlight-event payload, which can be `undefined`/`NaN` for raw `VariationDatum` objects. The canvas version uses `start` as the fallback when `end` is missing or non-numeric, so highlight events always carry a usable range.
+
 ## Performance
 
-See `dev/benchmarks/variation-canvas.html` for a reproducible benchmark comparing SVG vs canvas across variant counts.
+A reproducible benchmark comparing SVG vs canvas across variant counts lives at `dev/benchmarks/variation-canvas.html`. Run it with:
+
+```
+yarn benchmark:variation-canvas
+```
+
+That starts the dev server and opens the page in your browser. Click **Run benchmark** to start the sweep. No build step is required — the dev server compiles TypeScript on the fly and serves directly from `packages/*/src`.

--- a/packages/nightingale-variation-canvas/src/nightingale-variation-canvas.ts
+++ b/packages/nightingale-variation-canvas/src/nightingale-variation-canvas.ts
@@ -12,9 +12,8 @@ import { BaseType, Selection } from "d3";
 import { html } from "lit";
 
 // Re-declared locally because `ProcessedVariationData` is not exported from
-// `@nightingale-elements/nightingale-variation`'s public entry point, and the
-// spec forbids modifying that package. Keep this shape in sync with
-// `packages/nightingale-variation/src/nightingale-variation.ts`.
+// `@nightingale-elements/nightingale-variation`'s public entry point. Keep
+// this shape in sync with `packages/nightingale-variation/src/nightingale-variation.ts`.
 type ProcessedVariationData = {
   type: string;
   normal: string;
@@ -25,13 +24,20 @@ type ProcessedVariationData = {
 /** Default circle radius if `VariationDatum.size` is not provided. Mirrors SVG default in `variationPlot.ts`. */
 const DEFAULT_RADIUS = 5;
 
-/** Upper bound used when determining hit-test candidate positions; real `datum.size` values are typically ≤ 10. */
+/** Upper bound used when determining hit-test candidate positions; real `datum.size` values are typically ≤ 10.
+ * Variants with `size > MAX_HIT_RADIUS` still render, but their outer ring won't be hit-testable —
+ * `buildVariantIndex` warns once on the console when this is detected. */
 const MAX_HIT_RADIUS = 10;
 
 /** Base opacity for variant circles. Matches `circle { opacity: 0.6 }` in SVG variation CSS. */
 const VARIANT_ALPHA = 0.6;
 
-
+// TODO(deprecation): when `nightingale-variation` is removed, lift the shared
+// data-side logic (types, processVariants, proteinAPI, AA list, axis/y-scale
+// setup) into a base class or utility module rather than absorbing it
+// directly here. The current `extends withCanvas(NightingaleVariation)` is a
+// shortcut for the co-existence period; once the SVG version is gone, the
+// inheritance has to be undone.
 @customElementOnce("nightingale-variation-canvas")
 export default class NightingaleVariationCanvas extends withCanvas(
   NightingaleVariation,
@@ -42,6 +48,12 @@ export default class NightingaleVariationCanvas extends withCanvas(
   /** Variant currently under the mouse. Drawn at full opacity to mirror the
    * SVG `circle:hover { opacity: 1 }` affordance. */
   private hoveredVariant: VariationDatum | null = null;
+
+  /** Variant most recently dispatched on a `mouseover` event. Tracked separately
+   * from `hoveredVariant` so we only fire `mouseover` / `mouseout` on actual
+   * boundary crossings, not on every `mousemove` over the same circle (which
+   * would spam consumers — particularly anything bound via `highlight-event="onmouseover"`). */
+  private lastDispatchedVariant: VariationDatum | null = null;
 
   /** Foreground canvas layered above the SVG (via `pointer-events: none`), used
    * to redraw the hovered variant at full opacity on top of the SVG highlight
@@ -73,7 +85,7 @@ export default class NightingaleVariationCanvas extends withCanvas(
         <div style="position: relative; z-index: 0;">
           <canvas
             class="background"
-            style="position: absolute; left: 0; top: 0; z-index: -1;"
+            style="position: absolute; left: 0; top: 0; z-index: -1; pointer-events: none;"
           ></canvas>
           <svg>
             <g class="sequence-features" />
@@ -116,9 +128,8 @@ export default class NightingaleVariationCanvas extends withCanvas(
 
   override firstUpdated() {
     super.firstUpdated();
-    const foreground = this.renderRoot.querySelector<HTMLCanvasElement>(
-      "canvas.foreground",
-    );
+    const foreground =
+      this.renderRoot.querySelector<HTMLCanvasElement>("canvas.foreground");
     this.foregroundCanvasCtx = foreground?.getContext("2d") ?? undefined;
     if (foreground) {
       foreground.style.width = `${this.width}px`;
@@ -133,26 +144,42 @@ export default class NightingaleVariationCanvas extends withCanvas(
   }
 
   private readonly _backgroundStamp = new Stamp(() => ({
-    "processedData": this["processedData"],
-    "canvasCtx": this["canvasCtx"],
-    "width": this["width"],
-    "height": this["height"],
-    "canvasScale": this["canvasScale"],
-    "length": this["length"],
+    processedData: this["processedData"],
+    canvasCtx: this["canvasCtx"],
+    width: this["width"],
+    height: this["height"],
+    canvasScale: this["canvasScale"],
+    length: this["length"],
     "display-start": this["display-start"],
     "display-end": this["display-end"],
     "margin-left": this["margin-left"],
     "margin-right": this["margin-right"],
     "margin-top": this["margin-top"],
     "margin-bottom": this["margin-bottom"],
-    "condensedView": this["condensedView"],
-    "rowHeight": this["rowHeight"],
-    "colorConfig": this["colorConfig"],
+    condensedView: this["condensedView"],
+    rowHeight: this["rowHeight"],
+    colorConfig: this["colorConfig"],
   }));
 
   /** Request canvas redraw (debounced). */
   private requestDraw = () => this._drawer.requestRefresh();
   private readonly _drawer = Refresher(() => this._draw());
+
+  /** Resolvers for `whenDrawn()` promises waiting on the next `_draw` to finish. */
+  private _drawCompleteResolvers: Array<() => void> = [];
+
+  /** Returns a promise that resolves after the next `_draw` finishes. Useful
+   * for tests and benchmarks that need to await actual draw completion rather
+   * than guessing with `requestAnimationFrame`. The caller is expected to have
+   * just triggered a redraw (e.g. via `data =` or a `display-start`/`display-end`
+   * change); if no redraw is pending, the promise will not resolve until the
+   * next one happens. */
+  whenDrawn(): Promise<void> {
+    return new Promise((resolve) => {
+      this._drawCompleteResolvers.push(resolve);
+    });
+  }
+
   /** Do not call directly — call `requestDraw` instead to avoid blocking the main thread. */
   private _draw(): void {
     const backgroundChanged = this._backgroundStamp.update().changed;
@@ -164,6 +191,12 @@ export default class NightingaleVariationCanvas extends withCanvas(
     // hover changes without forcing a full background redraw.
     this.adjustForegroundCtxLogicalSize();
     this.drawForegroundContent();
+
+    if (this._drawCompleteResolvers.length > 0) {
+      const resolvers = this._drawCompleteResolvers;
+      this._drawCompleteResolvers = [];
+      for (const resolve of resolvers) resolve();
+    }
   }
 
   private adjustForegroundCtxLogicalSize() {
@@ -191,7 +224,8 @@ export default class NightingaleVariationCanvas extends withCanvas(
 
     const scale = this.canvasScale;
     const halfBaseWidth = 0.5 * this.getSingleBaseWidth();
-    const cx = scale * (this.getXFromSeqPosition(hovered.start) + halfBaseWidth);
+    const cx =
+      scale * (this.getXFromSeqPosition(hovered.start) + halfBaseWidth);
     const cy = scale * (this["margin-top"] + yRow);
     const r = scale * (hovered.size ?? DEFAULT_RADIUS);
 
@@ -214,10 +248,10 @@ export default class NightingaleVariationCanvas extends withCanvas(
 
     const scale = this.canvasScale;
     const halfBaseWidth = 0.5 * this.getSingleBaseWidth();
-    const leftEdgeSeq =
-      this.getSeqPositionFromX(-MAX_HIT_RADIUS) ?? -Infinity;
+    const leftEdgeSeq = this.getSeqPositionFromX(-MAX_HIT_RADIUS) ?? -Infinity;
     const rightEdgeSeq =
-      this.getSeqPositionFromX(canvasWidth / scale + MAX_HIT_RADIUS) ?? Infinity;
+      this.getSeqPositionFromX(canvasWidth / scale + MAX_HIT_RADIUS) ??
+      Infinity;
     const marginTop = this["margin-top"];
 
     ctx.globalAlpha = VARIANT_ALPHA;
@@ -329,7 +363,7 @@ export default class NightingaleVariationCanvas extends withCanvas(
     const withHighlight = this.getAttribute("highlight-event") === "onclick";
     const customEvent = createEvent(
       "click",
-      variant as unknown as Parameters<typeof createEvent>["1"],
+      variant,
       withHighlight,
       true,
       variant.start,
@@ -344,17 +378,33 @@ export default class NightingaleVariationCanvas extends withCanvas(
   private handleMousemove(event: MouseEvent): void {
     const coords = this.getLocalCoords(event);
     if (!coords) return;
-    const variant = this.getVariantAt(coords.x, coords.y);
-    if (!variant) {
-      this.handleMouseout(event);
-      return;
-    }
+    const variant = this.getVariantAt(coords.x, coords.y) ?? null;
     this.setHoveredVariant(variant);
+
+    // Only dispatch on transitions: empty→variant, variant→variant', variant→empty.
+    if (variant === this.lastDispatchedVariant) return;
+    if (this.lastDispatchedVariant) {
+      this.dispatchMouseout(event);
+    }
+    if (variant) {
+      this.dispatchMouseover(event, variant);
+    }
+    this.lastDispatchedVariant = variant;
+  }
+
+  private handleMouseout(event: MouseEvent): void {
+    this.setHoveredVariant(null);
+    if (!this.lastDispatchedVariant) return;
+    this.dispatchMouseout(event);
+    this.lastDispatchedVariant = null;
+  }
+
+  private dispatchMouseover(event: MouseEvent, variant: VariationDatum): void {
     const withHighlight =
       this.getAttribute("highlight-event") === "onmouseover";
     const customEvent = createEvent(
       "mouseover",
-      variant as unknown as Parameters<typeof createEvent>["1"],
+      variant,
       withHighlight,
       false,
       variant.start,
@@ -366,8 +416,7 @@ export default class NightingaleVariationCanvas extends withCanvas(
     this.dispatchEvent(customEvent);
   }
 
-  private handleMouseout(event: MouseEvent): void {
-    this.setHoveredVariant(null);
+  private dispatchMouseout(event: MouseEvent): void {
     const withHighlight =
       this.getAttribute("highlight-event") === "onmouseover";
     const customEvent = createEvent(
@@ -401,9 +450,22 @@ function buildVariantIndex(
 ): Map<number, VariationDatum[]> {
   const index = new Map<number, VariationDatum[]>();
   if (!mutationArray) return index;
+  let warnedOversized = false;
   for (const entry of mutationArray) {
     if (entry.variants.length === 0) continue;
     index.set(entry.pos, entry.variants);
+    if (!warnedOversized) {
+      for (const v of entry.variants) {
+        if ((v.size ?? 0) > MAX_HIT_RADIUS) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `nightingale-variation-canvas: variant size ${v.size} exceeds MAX_HIT_RADIUS=${MAX_HIT_RADIUS}; the outer ring will render but may not be hit-testable.`,
+          );
+          warnedOversized = true;
+          break;
+        }
+      }
+    }
   }
   return index;
 }

--- a/packages/nightingale-variation-canvas/tests/nightingale-variation-canvas.test.ts
+++ b/packages/nightingale-variation-canvas/tests/nightingale-variation-canvas.test.ts
@@ -1,5 +1,8 @@
 import NightingaleVariationCanvas from "../src/nightingale-variation-canvas";
-import type { VariationData } from "@nightingale-elements/nightingale-variation";
+import type {
+  VariationData,
+  VariationDatum,
+} from "@nightingale-elements/nightingale-variation";
 
 const minimalData: VariationData = {
   sequence: "MEEP",
@@ -58,5 +61,113 @@ describe("nightingale-variation-canvas", () => {
       element.data = minimalData;
     }).not.toThrow();
     expect(element.data).toBe(minimalData);
+  });
+});
+
+/**
+ * Event-dispatch tests: the canvas component reimplements pointer interaction
+ * on top of `mousemove`, so we explicitly assert that mouseover/mouseout fire
+ * once per actual enter/leave (not on every mousemove). This is the regression
+ * guard for the spam bug fixed in this package's first review pass.
+ *
+ * The hit-test logic itself depends on layout primitives (yScale,
+ * getXFromSeqPosition, getBoundingClientRect) that aren't reliable in jsdom,
+ * so we stub `getVariantAt` and `getLocalCoords` directly and verify the
+ * transition-tracking layer on top.
+ */
+describe("nightingale-variation-canvas event dispatch", () => {
+  let element: NightingaleVariationCanvas;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let internals: any;
+  let dispatched: Array<{ type: string; eventType: string }>;
+
+  const variantA: VariationDatum = {
+    accession: "vA",
+    variant: "A",
+    start: 2,
+    xrefNames: [],
+    hasPredictions: false,
+    consequenceType: "missense",
+  };
+  const variantB: VariationDatum = {
+    accession: "vB",
+    variant: "G",
+    start: 3,
+    xrefNames: [],
+    hasPredictions: false,
+    consequenceType: "missense",
+  };
+
+  beforeEach(() => {
+    element = new NightingaleVariationCanvas();
+    element.setAttribute("length", "4");
+    element.setAttribute("display-start", "1");
+    element.setAttribute("display-end", "4");
+    element.setAttribute("height", "200");
+    document.body.appendChild(element);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    internals = element as any;
+    internals.getLocalCoords = () => ({ x: 0, y: 0 });
+
+    dispatched = [];
+    element.addEventListener("change", (e: Event) => {
+      const ce = e as CustomEvent<{ eventType: string }>;
+      dispatched.push({ type: e.type, eventType: ce.detail?.eventType });
+    });
+  });
+
+  afterEach(() => {
+    document.body.removeChild(element);
+  });
+
+  function move(over: VariationDatum | null) {
+    internals.getVariantAt = () => over ?? undefined;
+    internals.handleMousemove(new MouseEvent("mousemove"));
+  }
+
+  test("fires mouseover exactly once when entering a variant", () => {
+    move(variantA);
+    move(variantA); // same variant — should not re-dispatch
+    move(variantA);
+    const overs = dispatched.filter((d) => d.eventType === "mouseover");
+    expect(overs).toHaveLength(1);
+  });
+
+  test("does not fire mouseout while moving over empty space", () => {
+    move(null);
+    move(null);
+    move(null);
+    const outs = dispatched.filter((d) => d.eventType === "mouseout");
+    expect(outs).toHaveLength(0);
+  });
+
+  test("fires mouseout once on leaving a variant for empty space", () => {
+    move(variantA);
+    dispatched.length = 0;
+    move(null);
+    move(null);
+    expect(dispatched.map((d) => d.eventType)).toEqual(["mouseout"]);
+  });
+
+  test("fires mouseout+mouseover when moving directly between variants", () => {
+    move(variantA);
+    dispatched.length = 0;
+    move(variantB);
+    expect(dispatched.map((d) => d.eventType)).toEqual([
+      "mouseout",
+      "mouseover",
+    ]);
+  });
+
+  test("native mouseout (leaving the SVG) clears the dispatch state", () => {
+    move(variantA);
+    dispatched.length = 0;
+    internals.handleMouseout(new MouseEvent("mouseout"));
+    expect(dispatched.map((d) => d.eventType)).toEqual(["mouseout"]);
+    // A subsequent mouseout should not double-fire.
+    internals.handleMouseout(new MouseEvent("mouseout"));
+    expect(
+      dispatched.filter((d) => d.eventType === "mouseout"),
+    ).toHaveLength(1);
   });
 });

--- a/packages/nightingale-variation/src/index.ts
+++ b/packages/nightingale-variation/src/index.ts
@@ -1,6 +1,9 @@
-import NightingaleVariation, {
-  VariationDatum,
-  VariationData,
-} from "./nightingale-variation";
-export { NightingaleVariation as default, VariationDatum, VariationData };
+import NightingaleVariation from "./nightingale-variation";
+export { NightingaleVariation as default };
+// Marked as `export type` so per-file transpilers (e.g. the dev server's
+// `ts.transpileModule` path) drop these from the JS output entirely. A plain
+// `export { … }` re-export forces TS to keep them as runtime bindings, which
+// then fails at module-link time in the browser because the source uses
+// `export type` for the underlying declarations.
+export type { VariationDatum, VariationData } from "./nightingale-variation";
 export * from "./proteinAPI";

--- a/web-dev-server.config.mjs
+++ b/web-dev-server.config.mjs
@@ -1,0 +1,65 @@
+import { createRequire } from "module";
+
+// Load `typescript` via createRequire so we get the package's CJS module
+// object (it isn't ESM-friendly via a default import in some Node versions).
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+
+const PACKAGE_PREFIX = "@nightingale-elements/";
+
+/*
+ * Resolves bare imports of `@nightingale-elements/<name>` to that package's
+ * source entry point in this monorepo, so `dev/` and `dev/benchmarks/` pages
+ * can run without a `yarn build` step. The dev server compiles TypeScript on
+ * the fly and serves source directly from each package's `src/index.ts`.
+ */
+const nightingaleSrcResolver = {
+  name: "nightingale-src-resolver",
+  resolveImport({ source }) {
+    if (!source.startsWith(PACKAGE_PREFIX)) return;
+    const name = source.slice(PACKAGE_PREFIX.length);
+    return `/packages/${name}/src/index.ts`;
+  },
+};
+
+/**
+ * Per-request TypeScript → JavaScript transpile using `ts.transpileModule`.
+ * Single-file transpile (no cross-file type checking) is exactly what the
+ * dev server needs — fast, no rollup dependency, no native binaries.
+ */
+const typescriptTranspilePlugin = {
+  name: "typescript-transpile",
+  transform(context) {
+    if (!context.path.endsWith(".ts") && !context.path.endsWith(".tsx")) return;
+    const source =
+      typeof context.body === "string"
+        ? context.body
+        : context.body?.toString("utf8") ?? "";
+    const result = ts.transpileModule(source, {
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2020,
+        module: ts.ModuleKind.ES2020,
+        experimentalDecorators: true,
+        useDefineForClassFields: false,
+        esModuleInterop: false,
+        allowSyntheticDefaultImports: true,
+        importHelpers: false,
+        inlineSources: true,
+        inlineSourceMap: true,
+        jsx: context.path.endsWith(".tsx") ? ts.JsxEmit.Preserve : undefined,
+      },
+      fileName: context.path,
+    });
+    return { body: result.outputText };
+  },
+};
+
+export default {
+  nodeResolve: true,
+  watch: true,
+  mimeTypes: {
+    "**/*.ts": "js",
+    "**/*.tsx": "js",
+  },
+  plugins: [nightingaleSrcResolver, typescriptTranspilePlugin],
+};


### PR DESCRIPTION
Small changes, a benchmarking convenience, and a doc tweak.

**Fix**
- `mousemove` no longer dispatches `mouseover` / `mouseout` on every pixel — only on actual enter/leave transitions. Adds 5 regression tests covering the transition cases.

**Benchmark / dev server**
- New `web-dev-server.config.mjs` resolves `@nightingale-elements/*` to each package's `src/index.ts` and transpiles TS on the fly, so `dev/benchmarks/*.html` runs without a `yarn build`.
- New `yarn benchmark:variation-canvas` script opens the benchmark page directly.
- New `NightingaleVariationCanvas#whenDrawn()` lets the benchmark await actual draw completion instead of guessing with double-RAF.

**Polish**
- `MAX_HIT_RADIUS` warns when a variant exceeds the hit-test cap.
- `pointer-events: none` on the background canvas (defense in depth).
- TODO on the `extends withCanvas(NightingaleVariation)` line capturing the migration cost when SVG is removed.
- Drop unnecessary `as unknown as Parameters<typeof createEvent>["1"]` casts — `VariationDatum` is structurally compatible.
- README: documents the `getVariantEnd` fallback as a second parity gap.

**Type re-export tweak**
- `packages/nightingale-variation/src/index.ts` uses `export type { … }` for the existing type re-exports. Same public API, but per-file transpilers (incl. the new dev server) now drop them at JS-emit time so the browser doesn't try to bind nonexistent runtime exports.