### PR TITLE
Scrollbox fixes

### DIFF
--- a/packages/nightingale-scrollbox/src/nightingale-scrollbox-item.ts
+++ b/packages/nightingale-scrollbox/src/nightingale-scrollbox-item.ts
@@ -86,7 +86,7 @@ export class NightingaleScrollboxItem<TData> extends NightingaleElement {
 
   private setContent(content: string | null | undefined) {
     if (content === undefined || content === null) return;
-    this.innerHTML = DOMPurify.sanitize(content);
+    this.innerHTML = DOMPurify.sanitize(content, { CUSTOM_ELEMENT_HANDLING: { tagNameCheck: /.*/, attributeNameCheck: /.*/, allowCustomizedBuiltInElements: true } });
   }
 
   /** Set or remove "onRegister" callback function. Also run this callback function if the item is already registered (i.e. in "new", "visible", or "hidden" state). */

--- a/packages/nightingale-scrollbox/src/nightingale-scrollbox.ts
+++ b/packages/nightingale-scrollbox/src/nightingale-scrollbox.ts
@@ -88,9 +88,9 @@ export class NightingaleScrollbox<TData> extends NightingaleElement {
       unregister: () => this.unregister(item),
     };
   }
-  /** Remove a scrollbox item and run "onUnregister" callback on it. This method is called automatically when a `nightingale-scrollbox-item` element is removed from the `nightingale-scrollbox` element. */
+  /** Remove a scrollbox item and run "onUnregister" callback on it. Do nothing if the item is not registered. This method is called automatically when a `nightingale-scrollbox-item` element is removed from the `nightingale-scrollbox` element. */
   unregister(item: NightingaleScrollboxItem<TData>) {
-    if (!this._items.has(item)) throw new Error(`Cannot unregister item ${item} because it is not registered.`)
+    if (!this._items.has(item)) return;
     this._items.delete(item);
     this.observer?.unobserve(item);
     item.unregister();

--- a/stories/19.NightingaleScrollbox/NightingaleScrollbox.stories.ts
+++ b/stories/19.NightingaleScrollbox/NightingaleScrollbox.stories.ts
@@ -3,7 +3,8 @@ import { html } from "lit-html";
 import { range } from "lodash-es";
 import "../../packages/nightingale-navigation/src/index";
 import "../../packages/nightingale-scrollbox/src/index";
-import { NightingaleScrollbox, NightingaleScrollboxItem } from "../../packages/nightingale-scrollbox/src/index";
+import type { NightingaleScrollbox, NightingaleScrollboxItem } from "../../packages/nightingale-scrollbox/src/index";
+import "../../packages/nightingale-track/src/index";
 
 
 export default {


### PR DESCRIPTION
This PR fixes two issues:
- Fix error `Cannot unregister item ... because it is not registered` when the whole scrollbox is disconnected from DOM (this was because `unregister` gets called twice (when disconnecting scrollbox and when disconnecting item).
- Allow custom HTML elements in `content-visible` and `content-hidden` via `DOMPurify.sanitize` config (this broke by introduction of `DOMPurify.sanitize` in https://github.com/ebi-webcomponents/nightingale/commit/2895b14d5bcf5ecb3a6ddc1dc2cc4c2ef3b9ac98)